### PR TITLE
refactor: IDE-31-AWS 람다 함수에 secretkey 추가 및 Controller에서 secretKey 검증

### DIFF
--- a/src/main/java/goorm/dbjj/ide/domain/outputlog/OutputSendingController.java
+++ b/src/main/java/goorm/dbjj/ide/domain/outputlog/OutputSendingController.java
@@ -3,8 +3,12 @@ package goorm.dbjj.ide.domain.outputlog;
 import goorm.dbjj.ide.domain.outputlog.dto.request.LogEntry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -12,11 +16,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class OutputSendingController {
 
+    @Value("${aws.lambda.secretKey}")
+    private String secretKey;
+
     private final OutputSendingService outputSendingService;
 
+    /**
+     * Lambda로부터 로그를 전송받습니다.
+     * 이후 로그를 사용자에게 전달합니다.
+     * @param logEntry 로그 정보가 담겨있습니다.
+     * @param requestSecretKey lambda에서 보내는 secretKey로, 이 값이 일치해야만 로그를 전송합니다.
+     *                        외부에서 API를 악성 호출하는 것을 방지합니다.
+     */
     @PostMapping("/api/execution/output")
-    public void sendOutput(@RequestBody LogEntry logEntry) {
+    public ResponseEntity<Void> sendOutput(
+            @RequestBody LogEntry logEntry,
+            @RequestParam("secretKey") String requestSecretKey
+    ) {
         log.debug("logEntry : {}", logEntry);
+
+        if(requestSecretKey == null || !requestSecretKey.equals(secretKey)) {
+            log.warn("secretKey가 일치하지 않습니다.");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         outputSendingService.sendTo(logEntry);
+
+        return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
기능 추가
* 외부에서 함부로 로그 전송 API를 호출할 수 없게 secretKey 검증 단계를 추가했습니다.

유의할 점
* 해당 커밋을 로컬로 가져오면 환경변수에 secretKey를 추가해야합니다.