### PR TITLE
IDE-35-project-api-model

### DIFF
--- a/src/main/java/goorm/dbjj/ide/config/SecurityConfig.java
+++ b/src/main/java/goorm/dbjj/ide/config/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
         return cors -> {
             CorsConfiguration configuration = new CorsConfiguration();
             configuration.addAllowedOrigin("http://localhost:3000"); // localhost:3000 에서만 요청 가능
+            configuration.addAllowedOrigin("http://localhost:8080"); // localhost:8080 에서만 요청 가능
             configuration.addAllowedMethod("*"); // GET, PUT, POST 다 가능
             configuration.addAllowedHeader("*"); // 모든 헤더 허용
             configuration.setAllowCredentials(true); // CORS 문제 해결

--- a/src/main/java/goorm/dbjj/ide/container/ContainerService.java
+++ b/src/main/java/goorm/dbjj/ide/container/ContainerService.java
@@ -2,7 +2,7 @@ package goorm.dbjj.ide.container;
 
 import goorm.dbjj.ide.api.exception.BaseException;
 import goorm.dbjj.ide.container.command.CommandStringBuilder;
-import goorm.dbjj.ide.domain.project.Project;
+import goorm.dbjj.ide.domain.project.model.Project;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/goorm/dbjj/ide/container/ContainerService.java
+++ b/src/main/java/goorm/dbjj/ide/container/ContainerService.java
@@ -1,144 +1,17 @@
 package goorm.dbjj.ide.container;
 
-import goorm.dbjj.ide.api.exception.BaseException;
-import goorm.dbjj.ide.container.command.CommandStringBuilder;
 import goorm.dbjj.ide.domain.project.model.Project;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-/**
- * IDE 컨테이너를 관리하는 서비스입니다.
- * https://www.notion.so/the-great-sign/3f49066725244273bde46265099f1242?pvs=4#5cdce6b1dee841769cd0b6acb2ea2b3e
- * <p>
- * - ContainerService는 다음과 같이 사용된다.
- * - ProjectService.createProject → 프로젝트를 생성하는데, 이 과정에서 RDS의 프로젝트의 메타데이터를 저장함과 동시에 사용될 컨테이너 이미지를 만들어야 한다.
- * - IDE 저장소와 협업 → IDE 세션에 한 명이라도 접근하면 컨테이너는 실행되어야 한다. IDE 세션에 아무도 존재하지 않는다면 컨테이너는 종료되어야 한다.
- * - 컨테이너의 중복 실행 문제를 막는다.
- * - 현재 사용자가 Container를 종료하고 실행할 수 있는 권한이 있는지 확인한다.
- * - 이 과정에서 ContainerService의 사용자가 직접적인 컨테이너와 관련된 정보를 모르도록 모든 외부 파라미터 정보는 Project로 받는다.
- */
-@Slf4j
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class ContainerService {
+public interface ContainerService {
+    void executeCommand(Project project, String path, String command, String userId);
 
-    private final ContainerUtil containerUtil;
-    private final MemoryContainerRepository memoryContainerRepository;
-    private final CommandStringBuilder commandStringBuilder;
-    private final ExecutionIdMapper executionIdMapper;
+    void createProjectImage(Project project);
 
-    /**
-     * 컨테이너에 명령을 실행시킵니다.
-     * 명령어로 나온 결과를 읽어 사용자에게 전달합니다.
-     * - 어떤 사용자에게 결과를 보내야하는지 알아야 하므로 유저 정보를 가져와야 합니다.
-     */
-    public void executeCommand(Project project, String path, String command, String userId) {
-        log.trace("ContainerService.executeCommand called");
+    void deleteProjectImage(Project project);
 
-        String containerId = memoryContainerRepository.find(project.getId());
-        if (containerId == null) {
-            throw new BaseException("컨테이너가 실행중이지 않습니다.");
-        }
+    void runContainer(Project project);
 
-        String sessionId = containerUtil.executeCommand(
-                containerId,
-                commandStringBuilder.createCommand(path,command)
-        );
+    void stopContainer(Project project);
 
-        executionIdMapper.put(sessionId, project.getId(), userId);
-    }
-
-    /**
-     * 프로젝트의 컨테이너 이미지를 생성합니다.
-     * 생성 권한 검증은 이 메서드를 사용하는 측에서 미리 검증함을 전제로 합니다.
-     *
-     * @param project
-     */
-    @Transactional(readOnly = true)
-    public void createProjectImage(Project project) {
-        log.trace("ContainerService.createProjectImage called");
-        /**
-         * todo: EFS에 AccessPoint를 생성하고 그 ID를 파라미터로 전달받아야합니다.
-         */
-        if (project.getContainerImageId() != null) {
-            throw new BaseException("컨테이너 이미지가 존재합니다.");
-        }
-
-        String containerImageId = containerUtil.createContainerImage(
-                project.getProgrammingLanguage(),
-                "accessPointId"
-        );
-
-        project.setContainerImageId(containerImageId);
-    }
-
-    /**
-     * 프로젝트 컨테이너 이미지를 삭제합니다.
-     * 삭제 권한은 이 메서드를 사용하는 측에서 검증해야합니다.
-     * @param project
-     */
-    public void deleteProjectImage(Project project) {
-        log.trace("ContainerService.deleteProjectImage called");
-
-        if (project.getContainerImageId() == null) {
-            throw new BaseException("컨테이너 이미지가 존재하지 않습니다.");
-        }
-
-        containerUtil.deleteContainerImage(project.getContainerImageId());
-        project.setContainerImageId(null);
-    }
-
-    /**
-     * 프로젝트의 컨테이너를 실행시킵니다.
-     * 만약 이미 실행중인 컨테이너가 있다면 예외를 발생시킵니다.
-     * 실행 권한은 메서드를 사용하는 측에서 미리 검증함을 전제로 합니다.
-     *
-     * @param project
-     */
-    public void runContainer(Project project) {
-        log.trace("ContainerService.runContainer called");
-
-        if (project.getContainerImageId() == null) {
-            throw new BaseException("컨테이너 이미지가 존재하지 않습니다.");
-        }
-
-        if (memoryContainerRepository.find(project.getId()) == null) {
-            String containerId = containerUtil.runContainer(project.getContainerImageId());
-            memoryContainerRepository.save(project.getId(), containerId);
-        } else {
-            throw new BaseException("이미 실행중인 컨테이너가 있습니다.");
-        }
-    }
-
-    /**
-     * 컨테이너를 종료합니다.
-     * 만약 컨테이너가 실행중이지 않다면 예외를 발생시킵니다.
-     * 종료 권한은 메서드를 사용하는 측에서 미리 검증함을 전제로 합니다.
-     *
-     * @param project
-     */
-    public void stopContainer(Project project) {
-        log.trace("ContainerService.stopContainer called");
-
-        String containerId = memoryContainerRepository.find(project.getId());
-        if (containerId != null) {
-            containerUtil.stopContainer(containerId);
-            memoryContainerRepository.remove(project.getId());
-        } else {
-            throw new BaseException("실행중인 컨테이너가 없습니다.");
-        }
-    }
-
-    /**
-     * 프로젝트의 컨테이너가 실행중인지 확인합니다.
-     *
-     * @param project
-     * @return
-     */
-    public boolean isContainerRunning(Project project) {
-        return memoryContainerRepository.find(project.getId()) != null;
-    }
+    boolean isContainerRunning(Project project);
 }

--- a/src/main/java/goorm/dbjj/ide/container/ContainerServiceImpl.java
+++ b/src/main/java/goorm/dbjj/ide/container/ContainerServiceImpl.java
@@ -1,0 +1,150 @@
+package goorm.dbjj.ide.container;
+
+import goorm.dbjj.ide.api.exception.BaseException;
+import goorm.dbjj.ide.container.command.CommandStringBuilder;
+import goorm.dbjj.ide.domain.project.model.Project;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * IDE 컨테이너를 관리하는 서비스입니다.
+ * https://www.notion.so/the-great-sign/3f49066725244273bde46265099f1242?pvs=4#5cdce6b1dee841769cd0b6acb2ea2b3e
+ * <p>
+ * - ContainerService는 다음과 같이 사용된다.
+ * - ProjectService.createProject → 프로젝트를 생성하는데, 이 과정에서 RDS의 프로젝트의 메타데이터를 저장함과 동시에 사용될 컨테이너 이미지를 만들어야 한다.
+ * - IDE 저장소와 협업 → IDE 세션에 한 명이라도 접근하면 컨테이너는 실행되어야 한다. IDE 세션에 아무도 존재하지 않는다면 컨테이너는 종료되어야 한다.
+ * - 컨테이너의 중복 실행 문제를 막는다.
+ * - 현재 사용자가 Container를 종료하고 실행할 수 있는 권한이 있는지 확인한다.
+ * - 이 과정에서 ContainerService의 사용자가 직접적인 컨테이너와 관련된 정보를 모르도록 모든 외부 파라미터 정보는 Project로 받는다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContainerServiceImpl implements ContainerService {
+
+    private final ContainerUtil containerUtil;
+    private final MemoryContainerRepository memoryContainerRepository;
+    private final CommandStringBuilder commandStringBuilder;
+    private final ExecutionIdMapper executionIdMapper;
+
+    /**
+     * 컨테이너에 명령을 실행시킵니다.
+     * 명령어로 나온 결과를 읽어 사용자에게 전달합니다.
+     * - 어떤 사용자에게 결과를 보내야하는지 알아야 하므로 유저 정보를 가져와야 합니다.
+     */
+    @Override
+    public void executeCommand(Project project, String path, String command, String userId) {
+        log.trace("ContainerService.executeCommand called");
+
+        String containerId = memoryContainerRepository.find(project.getId());
+        if (containerId == null) {
+            throw new BaseException("컨테이너가 실행중이지 않습니다.");
+        }
+
+        String sessionId = containerUtil.executeCommand(
+                containerId,
+                commandStringBuilder.createCommand(path,command)
+        );
+
+        executionIdMapper.put(sessionId, project.getId(), userId);
+    }
+
+    /**
+     * 프로젝트의 컨테이너 이미지를 생성합니다.
+     * 생성 권한 검증은 이 메서드를 사용하는 측에서 미리 검증함을 전제로 합니다.
+     *
+     * @param project
+     */
+    @Override
+    @Transactional
+    public void createProjectImage(Project project) {
+        log.trace("ContainerService.createProjectImage called");
+        /**
+         * todo: EFS에 AccessPoint를 생성하고 그 ID를 파라미터로 전달받아야합니다.
+         */
+        if (project.getContainerImageId() != null) {
+            throw new BaseException("컨테이너 이미지가 존재합니다.");
+        }
+
+        String containerImageId = containerUtil.createContainerImage(
+                project.getProgrammingLanguage(),
+                "accessPointId"
+        );
+
+        project.setContainerImageId(containerImageId);
+    }
+
+    /**
+     * 프로젝트 컨테이너 이미지를 삭제합니다.
+     * 삭제 권한은 이 메서드를 사용하는 측에서 검증해야합니다.
+     * @param project
+     */
+    @Override
+    public void deleteProjectImage(Project project) {
+        log.trace("ContainerService.deleteProjectImage called");
+
+        if (project.getContainerImageId() == null) {
+            throw new BaseException("컨테이너 이미지가 존재하지 않습니다.");
+        }
+
+        containerUtil.deleteContainerImage(project.getContainerImageId());
+        project.setContainerImageId(null);
+    }
+
+    /**
+     * 프로젝트의 컨테이너를 실행시킵니다.
+     * 만약 이미 실행중인 컨테이너가 있다면 예외를 발생시킵니다.
+     * 실행 권한은 메서드를 사용하는 측에서 미리 검증함을 전제로 합니다.
+     *
+     * @param project
+     */
+    @Override
+    public void runContainer(Project project) {
+        log.trace("ContainerService.runContainer called");
+
+        if (project.getContainerImageId() == null) {
+            throw new BaseException("컨테이너 이미지가 존재하지 않습니다.");
+        }
+
+        if (memoryContainerRepository.find(project.getId()) == null) {
+            String containerId = containerUtil.runContainer(project.getContainerImageId());
+            memoryContainerRepository.save(project.getId(), containerId);
+        } else {
+            throw new BaseException("이미 실행중인 컨테이너가 있습니다.");
+        }
+    }
+
+    /**
+     * 컨테이너를 종료합니다.
+     * 만약 컨테이너가 실행중이지 않다면 예외를 발생시킵니다.
+     * 종료 권한은 메서드를 사용하는 측에서 미리 검증함을 전제로 합니다.
+     *
+     * @param project
+     */
+    @Override
+    public void stopContainer(Project project) {
+        log.trace("ContainerService.stopContainer called");
+
+        String containerId = memoryContainerRepository.find(project.getId());
+        if (containerId != null) {
+            containerUtil.stopContainer(containerId);
+            memoryContainerRepository.remove(project.getId());
+        } else {
+            throw new BaseException("실행중인 컨테이너가 없습니다.");
+        }
+    }
+
+    /**
+     * 프로젝트의 컨테이너가 실행중인지 확인합니다.
+     *
+     * @param project
+     * @return
+     */
+    @Override
+    public boolean isContainerRunning(Project project) {
+        return memoryContainerRepository.find(project.getId()) != null;
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/container/ContainerServiceImpl.java
+++ b/src/main/java/goorm/dbjj/ide/container/ContainerServiceImpl.java
@@ -148,6 +148,6 @@ public class ContainerServiceImpl implements ContainerService {
      */
     @Override
     public boolean isContainerRunning(Project project) {
-        return memoryContainerRepository.find(project.getId()) != null;
+        return memoryContainerRepository.find(project.getId()).isRunning();
     }
 }

--- a/src/main/java/goorm/dbjj/ide/domain/project/Project.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/Project.java
@@ -5,7 +5,9 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
 import java.time.LocalDateTime;
 
 @Entity
@@ -28,8 +30,11 @@ public class Project {
 
     private String password;
 
-    @ColumnDefault("NOW()")
+    @CreationTimestamp
     private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
 
     // === 세터 == //
     public void setContainerImageId(String containerImageId) {

--- a/src/main/java/goorm/dbjj/ide/domain/project/ProjectRepository.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/ProjectRepository.java
@@ -1,5 +1,6 @@
 package goorm.dbjj.ide.domain.project;
 
+import goorm.dbjj.ide.domain.project.model.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectRepository extends JpaRepository<Project, String> {

--- a/src/main/java/goorm/dbjj/ide/domain/project/ProjectRepository.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/ProjectRepository.java
@@ -1,0 +1,6 @@
+package goorm.dbjj.ide.domain.project;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, String> {
+}

--- a/src/main/java/goorm/dbjj/ide/domain/project/ProjectService.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/ProjectService.java
@@ -1,0 +1,98 @@
+package goorm.dbjj.ide.domain.project;
+
+import goorm.dbjj.ide.api.exception.BaseException;
+import goorm.dbjj.ide.container.ContainerService;
+import goorm.dbjj.ide.domain.project.model.ProjectCreateRequestDto;
+import goorm.dbjj.ide.domain.project.model.Project;
+import goorm.dbjj.ide.domain.project.model.ProjectDto;
+import goorm.dbjj.ide.domain.user.dto.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 프로젝트의 CRUD를 담당하는 서비스 클래스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
+    private final ContainerService containerService;
+
+    /**
+     * 프로젝트 생성
+     * TODO: 추후 비밀번호는 암호화 필요
+     *
+     * @param requestDto
+     * @param userId
+     * @return
+     */
+    @Transactional
+    public ProjectDto createProject(ProjectCreateRequestDto requestDto, Long userId) {
+
+        /**
+         * TODO: 추후 비밀번호는 암호화 필요
+         */
+        Project project = Project.createProject(
+                requestDto.getName(),
+                requestDto.getDescription(),
+                requestDto.getProgrammingLanguage(),
+                requestDto.getPassword()
+        );
+
+        Project savedProject = projectRepository.save(project);
+
+        // 프로젝트 생성 시점에 컨테이너 이미지 생성
+        containerService.createProjectImage(project);
+
+        return ProjectDto.of(savedProject);
+    }
+
+    /**
+     * 프로젝트 비밀번호를 체크합니다.
+     * 비밀번호가 맞을 시, DB 작업을 통해 해당 유저가 프로젝트에 참여할 수 있는 권한을 부여합니다.
+     *
+     * @return 사용자가 프로젝트에 참여 가능하다면 true, 아니라면 false
+     */
+    @Transactional
+    public boolean enter(String requestPassword, String projectId, String userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException("존재하지 않는 유저입니다."));
+
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BaseException("존재하지 않는 프로젝트입니다."));
+
+        // 만약 이미 프로젝트에 참여하고 있다면 true를 반환
+
+        // 프로젝트에 참여하고 있지 않다면, 비밀번호를 체크하고 참여
+        if (project.getPassword().equals(requestPassword)) {
+            project.addUser(user);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+    @Transactional
+    public void deleteProject(String projectId, String userId) {
+
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BaseException("존재하지 않는 프로젝트입니다."));
+
+        if(!project.getUser().getId().equals(userId)) {
+            throw new BaseException("프로젝트 삭제 권한이 없습니다.");
+        }
+
+        /**
+         * TODO: 프로젝트 삭제 시, 컨테이너 이미지도 삭제해야 함
+         */
+
+        projectRepository.delete(project);
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/domain/project/ProjectUserRepository.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/ProjectUserRepository.java
@@ -1,0 +1,10 @@
+package goorm.dbjj.ide.domain.project;
+
+import goorm.dbjj.ide.domain.project.model.Project;
+import goorm.dbjj.ide.domain.project.model.ProjectUser;
+import goorm.dbjj.ide.domain.user.dto.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectUserRepository extends JpaRepository<ProjectUser, Long> {
+    boolean existsByProjectAndUser(Project project, User user);
+}

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
+@Table(name = "Projects")
 @Getter
 @NoArgsConstructor
 public class Project {

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
@@ -1,19 +1,19 @@
-package goorm.dbjj.ide.domain.project;
+package goorm.dbjj.ide.domain.project.model;
 
 import goorm.dbjj.ide.container.ProgrammingLanguage;
+import goorm.dbjj.ide.domain.user.dto.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class Project {
 
     @Id
@@ -36,9 +36,23 @@ public class Project {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // === 생성 팩토리 메서드 === //
+    public static Project createProject(String name, String description, ProgrammingLanguage programmingLanguage, String password) {
+        Project project = new Project();
+        project.id = UUID.randomUUID().toString();
+        project.name = name;
+        project.description = description;
+        project.programmingLanguage = programmingLanguage;
+        project.password = password;
+        return project;
+    }
+
     // === 세터 == //
     public void setContainerImageId(String containerImageId) {
         this.containerImageId = containerImageId;
     }
-
 }

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
@@ -42,7 +42,7 @@ public class Project {
     @JoinColumn(name = "creator_id")
     private User creator;
 
-    //User가 삭제될 때 Project도 삭제되도록 설정
+    //User가 삭제될 때 ProjectUser도 삭제되도록 설정
     @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE)
     private List<ProjectUser> projectUsers;
 

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
@@ -42,6 +42,9 @@ public class Project {
     @JoinColumn(name = "creator_id")
     private User creator;
 
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
+    private List<ProjectUser> projectUsers;
+
     // === 생성 팩토리 메서드 === //
     public static Project createProject(String name, String description, ProgrammingLanguage programmingLanguage, String password, User creator) {
         Project project = new Project();

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
@@ -42,7 +42,8 @@ public class Project {
     @JoinColumn(name = "creator_id")
     private User creator;
 
-    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
+    //User가 삭제될 때 Project도 삭제되도록 설정
+    @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE)
     private List<ProjectUser> projectUsers;
 
     // === 생성 팩토리 메서드 === //

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/Project.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -38,17 +39,18 @@ public class Project {
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @JoinColumn(name = "creator_id")
+    private User creator;
 
     // === 생성 팩토리 메서드 === //
-    public static Project createProject(String name, String description, ProgrammingLanguage programmingLanguage, String password) {
+    public static Project createProject(String name, String description, ProgrammingLanguage programmingLanguage, String password, User creator) {
         Project project = new Project();
         project.id = UUID.randomUUID().toString();
         project.name = name;
         project.description = description;
         project.programmingLanguage = programmingLanguage;
         project.password = password;
+        project.creator = creator;
         return project;
     }
 

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/ProjectCreateRequestDto.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/ProjectCreateRequestDto.java
@@ -1,0 +1,19 @@
+package goorm.dbjj.ide.domain.project.model;
+
+import goorm.dbjj.ide.container.ProgrammingLanguage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+public class ProjectCreateRequestDto {
+
+    private String name;
+    private String description;
+    private ProgrammingLanguage programmingLanguage;
+    private String password;
+}

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/ProjectDto.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/ProjectDto.java
@@ -1,0 +1,32 @@
+package goorm.dbjj.ide.domain.project.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Project 정보를 반환하기 위한 응답 DTO
+ */
+@AllArgsConstructor
+@Getter
+public class ProjectDto {
+
+    private String id;
+    private String name;
+    private String description;
+    private String programmingLanguage;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static ProjectDto of(Project project){
+        return new ProjectDto(
+                project.getId(),
+                project.getName(),
+                project.getDescription(),
+                project.getProgrammingLanguage().toString(),
+                project.getCreatedAt(),
+                project.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/ProjectUser.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/ProjectUser.java
@@ -1,0 +1,24 @@
+package goorm.dbjj.ide.domain.project.model;
+
+import goorm.dbjj.ide.domain.user.dto.User;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.*;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class ProjectUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "projects_id")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id")
+    private User user;
+}

--- a/src/main/java/goorm/dbjj/ide/domain/project/model/ProjectUser.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/model/ProjectUser.java
@@ -21,4 +21,9 @@ public class ProjectUser {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users_id")
     private User user;
+
+    public ProjectUser(Project project, User user) {
+        this.project = project;
+        this.user = user;
+    }
 }

--- a/src/test/java/goorm/dbjj/ide/container/ContainerServiceTest.java
+++ b/src/test/java/goorm/dbjj/ide/container/ContainerServiceTest.java
@@ -1,7 +1,7 @@
 package goorm.dbjj.ide.container;
 
 import goorm.dbjj.ide.container.command.CommandStringBuilder;
-import goorm.dbjj.ide.domain.project.Project;
+import goorm.dbjj.ide.domain.project.model.Project;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,14 +43,11 @@ class ContainerServiceTest {
             );
 
     private Project createProject() {
-        return new Project(
-                "id",
+        return Project.createProject(
                 "name",
                 "description",
-                null,
                 ProgrammingLanguage.PYTHON,
-                "password",
-                LocalDateTime.now()
+                "password"
         );
     }
     @AfterEach

--- a/src/test/java/goorm/dbjj/ide/container/ContainerServiceTest.java
+++ b/src/test/java/goorm/dbjj/ide/container/ContainerServiceTest.java
@@ -135,7 +135,7 @@ class ContainerServiceTest {
         // when
         //Project에는 ContainerImage가 없다.
         assertThat(project.getContainerImageId()).isNull();
-1
+
         // then
         //삭제 후에는 Project에 ContainerImage가 없어야 한다.
         assertThatThrownBy(() -> containerService.deleteProjectImage(project))

--- a/src/test/java/goorm/dbjj/ide/container/ContainerServiceTest.java
+++ b/src/test/java/goorm/dbjj/ide/container/ContainerServiceTest.java
@@ -3,59 +3,47 @@ package goorm.dbjj.ide.container;
 import goorm.dbjj.ide.api.exception.BaseException;
 import goorm.dbjj.ide.container.command.CommandStringBuilder;
 import goorm.dbjj.ide.domain.project.model.Project;
+import goorm.dbjj.ide.domain.user.dto.Role;
+import goorm.dbjj.ide.domain.user.dto.SocialType;
+import goorm.dbjj.ide.domain.user.dto.User;
+import goorm.dbjj.ide.mock.DummyContainerUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ContainerServiceTest {
-
-    static class DummyContainerUtil implements ContainerUtil {
-
-        @Override
-        public String executeCommand(String containerId, String command) {
-            return "sessionId";
-        }
-
-        @Override
-        public String createContainerImage(ProgrammingLanguage programmingLanguage, String accessPointId) {
-            return "containerImageId";
-        }
-
-        @Override
-        public void deleteContainerImage(String containerImageId) {
-
-        }
-
-        @Override
-        public String runContainer(String containerImageId) {
-            return "containerId";
-        }
-
-        @Override
-        public void stopContainer(String containerId) {
-        }
-    }
-
     private MemoryContainerRepository memoryContainerRepository = new MemoryContainerRepository();
-    private ContainerService containerService = new ContainerService(
+    private ContainerService containerService = new ContainerServiceImpl(
             new DummyContainerUtil(),
             memoryContainerRepository,
             new CommandStringBuilder(),
             new ExecutionIdMapper()
-            );
+    );
 
     private Project createProject() {
         return Project.createProject(
                 "name",
                 "description",
                 ProgrammingLanguage.PYTHON,
-                "password"
+                "password",
+                new User(1L,
+                        "email",
+                        "nickname",
+                        "password",
+                        Role.USER,
+                        SocialType.GOOGLE,
+                        "socialId",
+                        "refreshToken",
+                        LocalDateTime.now(),
+                        LocalDateTime.now())
         );
     }
+
     @AfterEach
     void afterEach() {
         memoryContainerRepository = new MemoryContainerRepository();
@@ -147,7 +135,7 @@ class ContainerServiceTest {
         // when
         //Project에는 ContainerImage가 없다.
         assertThat(project.getContainerImageId()).isNull();
-
+1
         // then
         //삭제 후에는 Project에 ContainerImage가 없어야 한다.
         assertThatThrownBy(() -> containerService.deleteProjectImage(project))

--- a/src/test/java/goorm/dbjj/ide/container/ContainerServiceTest.java
+++ b/src/test/java/goorm/dbjj/ide/container/ContainerServiceTest.java
@@ -3,7 +3,6 @@ package goorm.dbjj.ide.container;
 import goorm.dbjj.ide.api.exception.BaseException;
 import goorm.dbjj.ide.container.command.CommandStringBuilder;
 import goorm.dbjj.ide.lambdahandler.containerstatus.MemoryContainerRepository;
-import goorm.dbjj.ide.domain.project.Project;
 import goorm.dbjj.ide.domain.project.model.Project;
 import goorm.dbjj.ide.domain.user.dto.Role;
 import goorm.dbjj.ide.domain.user.dto.SocialType;
@@ -36,6 +35,7 @@ class ContainerServiceTest {
                 new User(1L,
                         "email",
                         "nickname",
+                        "imageUrl",
                         "password",
                         Role.USER,
                         SocialType.GOOGLE,

--- a/src/test/java/goorm/dbjj/ide/domain/project/ProjectServiceTest.java
+++ b/src/test/java/goorm/dbjj/ide/domain/project/ProjectServiceTest.java
@@ -63,6 +63,7 @@ class ProjectServiceTest {
                 "name",
                 "email",
                 "imageUrl",
+                "password",
                 Role.USER,
                 SocialType.GOOGLE,
                 "accessToken",

--- a/src/test/java/goorm/dbjj/ide/domain/project/ProjectServiceTest.java
+++ b/src/test/java/goorm/dbjj/ide/domain/project/ProjectServiceTest.java
@@ -1,0 +1,158 @@
+package goorm.dbjj.ide.domain.project;
+
+import goorm.dbjj.ide.container.ContainerService;
+import goorm.dbjj.ide.container.ProgrammingLanguage;
+import goorm.dbjj.ide.domain.project.model.Project;
+import goorm.dbjj.ide.domain.project.model.ProjectCreateRequestDto;
+import goorm.dbjj.ide.domain.project.model.ProjectDto;
+import goorm.dbjj.ide.domain.user.UserRepository;
+import goorm.dbjj.ide.domain.user.dto.Role;
+import goorm.dbjj.ide.domain.user.dto.SocialType;
+import goorm.dbjj.ide.domain.user.dto.User;
+import goorm.dbjj.ide.mock.DummyContainerService;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ProjectService를 Spring Context에서 테스트하기 위한 클래스
+ * ContainerService만 모킹하여 사용합니다. (AWS SDK 사용하기 때문)
+ */
+@SpringBootTest
+@Import(ProjectServiceTest.Config.class)
+@Transactional
+class ProjectServiceTest {
+
+    @Autowired
+    ProjectService projectService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ContainerService containerService;
+
+    @Autowired
+    ProjectUserRepository projectUserRepository;
+
+    @Autowired
+    ProjectRepository projectRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @AfterEach
+    void afterEach() {
+        DummyContainerService dummyContainerService= (DummyContainerService) containerService;
+        dummyContainerService.clearMethodCallCount();
+    }
+
+    private User createUser() {
+        return new User(
+                1L,
+                "name",
+                "email",
+                "imageUrl",
+                Role.USER,
+                SocialType.GOOGLE,
+                "accessToken",
+                "refreshToken",
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        public ContainerService containerService() {
+            return new DummyContainerService();
+        }
+    }
+
+    @Test
+    void createProjectSuccess() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        ProjectCreateRequestDto requestDto = new ProjectCreateRequestDto(
+                "name",
+                "description",
+                ProgrammingLanguage.PYTHON,
+                "password"
+                );
+
+        // when
+        ProjectDto projectDto = projectService.createProject(requestDto, user.getId());
+
+        em.flush();
+        em.clear();
+
+        // then
+        User creator = userRepository.findById(user.getId()).get();
+        Project project = projectRepository.findById(projectDto.getId()).get();
+
+        //DB에 프로젝트 정보가 잘 저장되어있어야 한다.
+        assertThat(project.getName()).isEqualTo(requestDto.getName());
+        assertThat(project.getDescription()).isEqualTo(requestDto.getDescription());
+        assertThat(project.getProgrammingLanguage()).isEqualTo(requestDto.getProgrammingLanguage());
+        assertThat(project.getPassword()).isEqualTo(requestDto.getPassword());
+        assertThat(project.getCreator()).isEqualTo(creator);
+
+        // 프로젝트 생성과 함께 creator가 프로젝트에 참여하도록 함
+        assertThat(projectUserRepository.existsByProjectAndUser(project, creator)).isTrue();
+        assertThat(projectUserRepository.count()).isEqualTo(1);
+
+        // 프로젝트 생성 시점에 컨테이너 이미지 생성
+        assertThat(project.getContainerImageId()).isNotNull();
+    }
+
+
+    /**
+     * 프로젝트를 삭제하는 테스트입니다.
+     * 원래는 프로젝트 생성과 독립적으로 수행되어야 하는 것이 맞지만, 편의상 프로젝트 생성과 함께 수행합니다.
+     */
+    @Test
+    void deleteProjectSuccess() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        ProjectCreateRequestDto requestDto = new ProjectCreateRequestDto(
+                "name",
+                "description",
+                ProgrammingLanguage.PYTHON,
+                "password"
+                );
+
+        ProjectDto projectDto = projectService.createProject(requestDto, user.getId());
+
+        em.flush();
+        em.clear();
+
+        // when
+        projectService.deleteProject(projectDto.getId(), user.getId());
+
+        em.flush();
+        em.clear();
+
+        // then
+        DummyContainerService dummyContainerService= (DummyContainerService) containerService;
+
+        assertThat(projectRepository.count()).isEqualTo(0);
+        assertThat(projectUserRepository.count()).isEqualTo(0);
+        assertThat(dummyContainerService.getMethodCallCount("deleteProjectImage")).isEqualTo(1);
+        assertThat(dummyContainerService.getMethodCallCount("stopContainer")).isEqualTo(1);
+    }
+}

--- a/src/test/java/goorm/dbjj/ide/mock/DummyContainerService.java
+++ b/src/test/java/goorm/dbjj/ide/mock/DummyContainerService.java
@@ -1,0 +1,52 @@
+package goorm.dbjj.ide.mock;
+
+import goorm.dbjj.ide.container.ContainerService;
+import goorm.dbjj.ide.domain.project.model.Project;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class DummyContainerService implements ContainerService {
+
+    private Map<String, Long> methodCallCountMap = new HashMap<>();
+
+    @Override
+    public void executeCommand(Project project, String path, String command, String userId) {
+    }
+
+    @Override
+    public void createProjectImage(Project project) {
+        log.info("DummyContainerService.createProjectImage called");
+        project.setContainerImageId("containerImageId");
+    }
+
+    @Override
+    public void deleteProjectImage(Project project) {
+        methodCallCountMap.put("deleteProjectImage", methodCallCountMap.getOrDefault("deleteProjectImage", 0L) + 1);
+    }
+
+    @Override
+    public void runContainer(Project project) {
+
+    }
+
+    @Override
+    public void stopContainer(Project project) {
+        methodCallCountMap.put("stopContainer", methodCallCountMap.getOrDefault("stopContainer", 0L) + 1);
+    }
+
+    @Override
+    public boolean isContainerRunning(Project project) {
+        return false;
+    }
+
+    public long getMethodCallCount(String methodName) {
+        return methodCallCountMap.getOrDefault(methodName, 0L);
+    }
+
+    public void clearMethodCallCount() {
+        methodCallCountMap.clear();
+    }
+}

--- a/src/test/java/goorm/dbjj/ide/mock/DummyContainerUtil.java
+++ b/src/test/java/goorm/dbjj/ide/mock/DummyContainerUtil.java
@@ -1,0 +1,31 @@
+package goorm.dbjj.ide.mock;
+
+import goorm.dbjj.ide.container.ContainerUtil;
+import goorm.dbjj.ide.container.ProgrammingLanguage;
+
+public class DummyContainerUtil implements ContainerUtil {
+
+
+    @Override
+    public String executeCommand(String containerId, String command) {
+        return "sessionId";
+    }
+
+    @Override
+    public String createContainerImage(ProgrammingLanguage programmingLanguage, String accessPointId) {
+        return "containerImageId";
+    }
+
+    @Override
+    public void deleteContainerImage(String containerImageId) {
+    }
+
+    @Override
+    public String runContainer(String containerImageId) {
+        return "containerId";
+    }
+
+    @Override
+    public void stopContainer(String containerId) {
+    }
+}


### PR DESCRIPTION
기능 추가
* Controller를 제외한 계층의 Project 관련 코드를 작성했습니다.
  * Project 엔티티 개발
  * ProjectUser 엔티티 개발 및 연관관계 매핑
  * ProjectRepository, ProjectUserRepository 개발
  * ProjectService 개발 (프로젝트 생성, 삭제, 입장)
* 테스트 코드 작성
  * 기존에 있었던 더미 객체 외부로 분리
  * ProjectService 테스트코드 작성

특이 사항
코드가 많아졌습니다 ㅠ 앞으로는 좀더 잘개 조개서 해보겟습니다.