### PR TITLE
IDE-67 FileWatcher 모듈 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 
     // efs
     implementation 'software.amazon.awssdk:efs:2.17.0'
+
+    //Apache Common IO
+    implementation 'commons-io:commons-io:2.15.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcher.java
+++ b/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcher.java
@@ -1,0 +1,67 @@
+package goorm.dbjj.ide.util.filewatcher;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
+import org.apache.commons.io.monitor.FileAlterationMonitor;
+import org.apache.commons.io.monitor.FileAlterationObserver;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+
+@Slf4j
+@Component("myFileWatcher")
+public class FileWatcher {
+
+    public void watch(String dir) throws Exception {
+
+        FileAlterationObserver observer = new FileAlterationObserver(dir);
+
+        observer.addListener(new FileAlterationListenerAdaptor() {
+
+            @Override
+            public void onDirectoryChange(File directory) {
+//                System.out.println("modified directory = " + directory);
+            }
+
+            @Override
+            public void onDirectoryCreate(File directory) {
+                sendToUser(extractProjectId(directory.getPath()));
+            }
+
+            @Override
+            public void onDirectoryDelete(File directory) {
+                System.out.println("delete directory = " + directory);
+            }
+
+            @Override
+            public void onFileCreate(File file) {
+                sendToUser(extractProjectId(file.getPath()));
+            }
+
+            @Override
+            public void onFileDelete(File file) {
+                sendToUser(extractProjectId(file.getPath()));
+            }
+        });
+
+        FileAlterationMonitor monitor = new FileAlterationMonitor(1000);
+        monitor.addObserver(observer);
+
+        monitor.start();
+        log.info("File Watcher Start, dir : {}", dir);
+    }
+
+    /**
+     * 프로젝트의 파일이 변경되었을 때, 해당 프로젝트를 사용하는 유저들에게 변경사항을 알립니다.
+     * WS로 변경됐음을 전송합니다.
+     * @param projectId
+     */
+    private void sendToUser(String projectId) {
+        System.out.println("sendToUser = " + projectId);
+    }
+
+    private String extractProjectId(String path) {
+        String[] split = path.split("/");
+        return split[5];
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcher.java
+++ b/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcher.java
@@ -8,8 +8,15 @@ import org.springframework.stereotype.Component;
 
 import java.io.File;
 
+/**
+ * FileWatcher
+ *
+ * FileWatcher은 EFS 스토리지의 디렉터리를 감시하고,
+ * 디렉터리에 변경사항이 생길 때 이를 사용자에게 알리는 역할을 합니다.
+ * 이를 통해 File의 CRUD 로직에서 생기는 '사용자에게 알리는 책임'을 분리해낼 수 있습니다
+ */
 @Slf4j
-@Component("myFileWatcher")
+@Component("myFileWatcher") //SslAutoConfiguration에 이미 FileWatcher가 등록되어 있어서 이름을 변경해줘야 합니다.
 public class FileWatcher {
 
     public void watch(String dir) throws Exception {
@@ -33,6 +40,10 @@ public class FileWatcher {
                 System.out.println("delete directory = " + directory);
             }
 
+            /**
+             * 현재 swap 파일의 생성 역시 감지되는 이슈가 있습니다.
+             * @param file The file created (ignored)
+             */
             @Override
             public void onFileCreate(File file) {
                 sendToUser(extractProjectId(file.getPath()));
@@ -42,13 +53,15 @@ public class FileWatcher {
             public void onFileDelete(File file) {
                 sendToUser(extractProjectId(file.getPath()));
             }
+
         });
 
+        // 1초마다 변경사항을 감지합니다.
         FileAlterationMonitor monitor = new FileAlterationMonitor(1000);
         monitor.addObserver(observer);
 
         monitor.start();
-        log.info("File Watcher Start, dir : {}", dir);
+        log.info("FileWatcher Start, dir : {}", dir);
     }
 
     /**
@@ -57,11 +70,26 @@ public class FileWatcher {
      * @param projectId
      */
     private void sendToUser(String projectId) {
-        System.out.println("sendToUser = " + projectId);
+        if(projectId != null) {
+            //do nothing
+        } else {
+            //WS로 변경사항을 전송합니다.
+            System.out.println("sendToUser = " + projectId);
+        }
     }
 
+    /**
+     * EFS 스토리지의 디렉터리 경로에서 프로젝트 아이디를 추출합니다.
+     * 로컬에서는 작동하지 않습니다.
+     * @param path
+     * @return
+     */
     private String extractProjectId(String path) {
-        String[] split = path.split("/");
-        return split[5];
+        try { // 로컬 개발환경에서 NPE 발생을 막아주기 위해 try로 감싸줍니다.
+            String[] split = path.split("/");
+            return split[5];
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcherRunner.java
+++ b/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcherRunner.java
@@ -6,6 +6,12 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
+/**
+ * FileWatcherRunner
+ *
+ * FileWatcher를 애플리케이션 로딩이 끝난 시점에 수행시키는 역할을 합니다.
+ * 파일을 감지하는 위치는 aws.efs.mountPoint에서 정의합니다.
+ */
 @Component("myFileWatcherRunner")
 @RequiredArgsConstructor
 public class FileWatcherRunner implements ApplicationRunner {

--- a/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcherRunner.java
+++ b/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcherRunner.java
@@ -1,0 +1,22 @@
+package goorm.dbjj.ide.util.filewatcher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component("myFileWatcherRunner")
+@RequiredArgsConstructor
+public class FileWatcherRunner implements ApplicationRunner {
+
+    @Value("${aws.efs.mountPoint}")
+    private String baseDir;
+
+    private final FileWatcher fileWatcher;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        fileWatcher.watch(baseDir);
+    }
+}

--- a/src/test/java/goorm/dbjj/ide/util/filewatcher/FileWatcherTest.java
+++ b/src/test/java/goorm/dbjj/ide/util/filewatcher/FileWatcherTest.java
@@ -1,0 +1,31 @@
+package goorm.dbjj.ide.util.filewatcher;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FileWatcherTest {
+
+    FileWatcher fileWatcher = new FileWatcher();
+
+    @Test
+    @Disabled
+    void watchTest() throws InterruptedException, IOException {
+        try {
+            fileWatcher.watch("/Users/goorm/Desktop/test");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+
+        File file = new File("/Users/goorm/Desktop/test/app/p1/test.txt");
+        file.createNewFile();
+
+        Thread.sleep(2000);
+        file.delete();
+    }
+}


### PR DESCRIPTION
기능 추가
* EFS 디렉터리의 변경사항을 읽기 위한 FileWatcher 클래스를 개발했습니다.

특이 사항
* WS 전송 로직이 완료되면 해당 기능을 통해 사용자에게 전달하는 로직을 추가해야합니다.
* 의사결정 사항이 있습니다.
   * 웹소켓 메시지로 변경된 디렉터리 구조를 직접 보낼 것인가?
   * 디렉터리가 변경되었다는 정보만 알리고 사용자에게 디렉터리 구조를 HTTP로 새롭게 요청할 것을 유도할 것인가
* aws.properties에 aws.efs.mountPoint를 지정해주어야 합니다. 해당 내용은 슬랙에 올리겠습니다.