### PR TITLE
IDE-74 terminal DB 조회 로직 리팩터링

### DIFF
--- a/src/main/java/goorm/dbjj/ide/websocket/WebSocketUser.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/WebSocketUser.java
@@ -4,7 +4,6 @@ import goorm.dbjj.ide.websocket.dto.UserInfoDto;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,27 +33,14 @@ public class WebSocketUser {
     public boolean isSubscribe(String subscribeType){
         log.info("subscribeType {}", subscribeType);
         
-        // 구독하고 있다면
-        if(this.subscribes.stream().anyMatch(s -> s.equals(subscribeType))){
-            return true;
-        }
-        // 구독 안하고 있다면
-        return false;
+        // 구독하고 있다면 true, 안하면 false
+        return this.subscribes.stream().anyMatch(s -> s.equals(subscribeType));
     }
 
     /**
-    * 이미 실행중인 프로젝트인지 비교할때 사용
-    * */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        WebSocketUser that = (WebSocketUser) o;
-        return Objects.equals(userInfoDto, that.userInfoDto) && Objects.equals(projectId, that.projectId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(userInfoDto, projectId);
+     * userId와 projectId 두개가 동일한 객체가 존재하는지 비교문
+     * */
+    public boolean isSameWith(Long userId, String projectId){
+        return this.userInfoDto.getId().equals(userId) && this.projectId.equals(projectId);
     }
 }

--- a/src/main/java/goorm/dbjj/ide/websocket/WebSocketUserSessionMapper.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/WebSocketUserSessionMapper.java
@@ -45,10 +45,11 @@ public class WebSocketUserSessionMapper {
      * userInfoDto와 projectId를 이용해서 세션키를 찾는 로직
      * @return sessionId
      * */
-    public String findSessionIdByProjectAndUserInfoDto(UserInfoDto userInfoDto, String projectId) {
+    public String findSessionIdByProjectAndUserInfoDto(Long userId, String projectId) {
         return webSocketUserSessionMap.entrySet()
                 .stream()
-                .filter(entry -> new WebSocketUser(userInfoDto, projectId).equals(entry.getValue()))
+//                .filter(entry -> new WebSocketUser(userInfoDto, projectId).equals(entry.getValue()))
+                .filter(entry -> entry.getValue().isSameWith(userId, projectId))
                 .map(Map.Entry::getKey)
                 .findFirst()
                 .orElse(null);

--- a/src/main/java/goorm/dbjj/ide/websocket/dto/UserInfoDto.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/dto/UserInfoDto.java
@@ -22,18 +22,29 @@ public class UserInfoDto {
     }
 
     /**
+     * 터미널, 파일디렉터리 등 userId를 단순히 비교만 하는경우에 사용한다.
+     * */
+    public UserInfoDto(Long id){
+        this.id=id;
+        this.email=null;
+        this.nickname=null;
+    }
+
+
+    /**
     * 웹소켓이 이미 실행되고 있는지 비교하기 위해 생성
+     * id 값만 비교 => db 조회 덜하기 위한 조치
     * */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UserInfoDto that = (UserInfoDto) o;
-        return Objects.equals(id, that.id) && Objects.equals(email, that.email) && Objects.equals(nickname, that.nickname);
+        return Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, email, nickname);
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/goorm/dbjj/ide/websocket/dto/UserInfoDto.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/dto/UserInfoDto.java
@@ -5,8 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Objects;
-
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
@@ -19,32 +17,5 @@ public class UserInfoDto {
         this.id = user.getId();
         this.email = user.getEmail();
         this.nickname = user.getNickname();
-    }
-
-    /**
-     * 터미널, 파일디렉터리 등 userId를 단순히 비교만 하는경우에 사용한다.
-     * */
-    public UserInfoDto(Long id){
-        this.id=id;
-        this.email=null;
-        this.nickname=null;
-    }
-
-
-    /**
-    * 웹소켓이 이미 실행되고 있는지 비교하기 위해 생성
-     * id 값만 비교 => db 조회 덜하기 위한 조치
-    * */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        UserInfoDto that = (UserInfoDto) o;
-        return Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
     }
 }

--- a/src/main/java/goorm/dbjj/ide/websocket/terminal/TerminalController.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/terminal/TerminalController.java
@@ -3,7 +3,6 @@ package goorm.dbjj.ide.websocket.terminal;
 import goorm.dbjj.ide.lambdahandler.executionoutput.ExecutionOutputDto;
 import goorm.dbjj.ide.websocket.WebSocketUser;
 import goorm.dbjj.ide.websocket.WebSocketUserSessionMapper;
-import goorm.dbjj.ide.websocket.dto.UserInfoDto;
 import goorm.dbjj.ide.websocket.terminal.dto.TerminalExecuteRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +43,7 @@ public class TerminalController {
      * */
     public void terminalExecutionResult(String projectId, Long userId, ExecutionOutputDto executionOutputDto){
         log.trace("terminalExecutionResult execute");
-        String sessionId = webSocketUserSessionMapper.findSessionIdByProjectAndUserInfoDto(new UserInfoDto(userId), projectId);
+        String sessionId = webSocketUserSessionMapper.findSessionIdByProjectAndUserInfoDto(userId, projectId);
 
         simpMessagingTemplate.convertAndSendToUser(sessionId,"/queue/project/"+projectId +"/terminal", executionOutputDto);
     }

--- a/src/main/java/goorm/dbjj/ide/websocket/terminal/TerminalController.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/terminal/TerminalController.java
@@ -44,8 +44,7 @@ public class TerminalController {
      * */
     public void terminalExecutionResult(String projectId, Long userId, ExecutionOutputDto executionOutputDto){
         log.trace("terminalExecutionResult execute");
-        UserInfoDto userEmailByUserId = terminalService.getUserInfoDtoByUserId(userId);
-        String sessionId = webSocketUserSessionMapper.findSessionIdByProjectAndUserInfoDto(userEmailByUserId, projectId);
+        String sessionId = webSocketUserSessionMapper.findSessionIdByProjectAndUserInfoDto(new UserInfoDto(userId), projectId);
 
         simpMessagingTemplate.convertAndSendToUser(sessionId,"/queue/project/"+projectId +"/terminal", executionOutputDto);
     }
@@ -61,5 +60,4 @@ public class TerminalController {
         WebSocketUser webSocketUser = webSocketUserSessionMapper.get(uuid);
         return webSocketUser.getUserInfoDto().getId();
     }
-
 }

--- a/src/main/java/goorm/dbjj/ide/websocket/terminal/TerminalService.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/terminal/TerminalService.java
@@ -4,23 +4,21 @@ import goorm.dbjj.ide.api.exception.BaseException;
 import goorm.dbjj.ide.container.ContainerService;
 import goorm.dbjj.ide.domain.project.ProjectRepository;
 import goorm.dbjj.ide.domain.project.model.Project;
-import goorm.dbjj.ide.domain.user.UserRepository;
-import goorm.dbjj.ide.domain.user.dto.User;
-import goorm.dbjj.ide.websocket.dto.UserInfoDto;
 import goorm.dbjj.ide.websocket.terminal.dto.TerminalExecuteRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TerminalService {
     private final ContainerService containerService;
     private final ProjectRepository projectRepository;
-    private final UserRepository userRepository;
 
     /**
      * Terminal 실행 명령어
@@ -34,13 +32,5 @@ public class TerminalService {
         }
 
         containerService.executeCommand(projectOptional.get(), terminalExecuteRequestDto.getPath(), terminalExecuteRequestDto.getCommand(), userId);
-    }
-
-    /**
-    * UserId를 이용해서 UserRepository를 조회하고 UserEmail을 반환하는 로직.
-    * */
-    public UserInfoDto getUserInfoDtoByUserId(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new BaseException("유저가 존재하지 않습니다"));
-        return new UserInfoDto(user);
     }
 }


### PR DESCRIPTION
- 변경사항
  - DB 조회하는 부분에 Transcation(readOnly=true) 설정으로 더 빠르게 동작하도록 설정
  - UserInfoDto의 equals를 userId만 비교하게 해서 db 조회없이 WebSocketUserSessionMapper의 key값 가져올 수 있게 리팩터링
  - 로컬에서 테스트 결과 잘 동작하였습니다!