### PR TITLE
IDE-22 UserDetails null 처리, response body에 유저 정보 넣기

### DIFF
--- a/src/main/java/goorm/dbjj/ide/auth/jwt/JwtAuthProvider.java
+++ b/src/main/java/goorm/dbjj/ide/auth/jwt/JwtAuthProvider.java
@@ -36,6 +36,7 @@ public class JwtAuthProvider {
 
     /**
      * JWT를 사용해서 사용자 인증 정보 추출, Authentication에 담기.
+     *  유저 정보가 비어있다면 exception.
      */
     public Authentication getAuthentication(String token){
         Claims claims = jwtIssuer.getClaims(token);

--- a/src/main/java/goorm/dbjj/ide/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/goorm/dbjj/ide/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -73,7 +73,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         response.setStatus(HttpServletResponse.SC_OK);
 
         // 콘텐츠 타입 설정
-        response.setContentType("application/json");
+        response.setContentType("application/json; charset=UTF-8");
 
         User user = userRepository.findByEmail(oAuth2User.getEmail())
                 .orElseThrow(() -> new EntityNotFoundException("유저 정보가 없습니다."));
@@ -85,7 +85,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         responseMap.put("nickname", user.getNickname());
         responseMap.put("email", user.getEmail());
         responseMap.put("image_url", user.getImageUrl());
-        responseMap.put("created_at", user.getCreatedAt());
+        responseMap.put("created_at", user.getCreatedAt().toString());
 
         // Map을 Json 문자열로 변환
         String jsonResponse = mapper.writeValueAsString(responseMap);


### PR DESCRIPTION
**변경사항**
- JwtAuthProvider
  - 인증된 객체를 생성하기 전, 사용자의 세부 정보를 load하는데 세부 정보가 null이라면, exception 처리.
- OAuth2LoginSuccessHandler
  - 로그인 후 jwt를 헤더에 넣어서 보낼 때, response body에 유저 정보 같이 넣어서 전달.