### PR TITLE
IDE-82 sockjs추가설정

### DIFF
--- a/src/main/java/goorm/dbjj/ide/websocket/WebSocketConfig.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/WebSocketConfig.java
@@ -43,7 +43,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer { // �
                 .addInterceptors(webSocketHandShack); // HTTP Upgrade 시 사용하는 인터셉터
 
         // withSockJS사용용
-        registry.addEndpoint("/ws/ide/{projectId}")
+        registry.addEndpoint("/ws/ide/{projectId}/info")
                 .setAllowedOriginPatterns("*")
                 .setHandshakeHandler(customHandShakeHandler)
                 .addInterceptors(webSocketHandShack) // HTTP Upgrade 시 사용하는 인터셉터


### PR DESCRIPTION
**변경사항**
- sockjs 호환을 위해 허용경로를 /ws/ide/{projectId}/info 로 변경하였습니다.