### PR TITLE
IDE-79 refreshToken이 들어오면 JWT 토큰 재발행

### DIFF
--- a/src/main/java/goorm/dbjj/ide/api/exception/UnAuthorizedException.java
+++ b/src/main/java/goorm/dbjj/ide/api/exception/UnAuthorizedException.java
@@ -1,0 +1,7 @@
+package goorm.dbjj.ide.api.exception;
+
+public class UnAuthorizedException extends RuntimeException{
+    public UnAuthorizedException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/auth/jwt/JwtAuthProvider.java
+++ b/src/main/java/goorm/dbjj/ide/auth/jwt/JwtAuthProvider.java
@@ -36,6 +36,7 @@ public class JwtAuthProvider {
 
     /**
      * JWT를 사용해서 사용자 인증 정보 추출, Authentication에 담기.
+     *  유저 정보가 비어있다면 exception.
      */
     public Authentication getAuthentication(String token){
         Claims claims = jwtIssuer.getClaims(token);

--- a/src/main/java/goorm/dbjj/ide/auth/jwt/JwtAuthProvider.java
+++ b/src/main/java/goorm/dbjj/ide/auth/jwt/JwtAuthProvider.java
@@ -1,6 +1,10 @@
 package goorm.dbjj.ide.auth.jwt;
 
+import goorm.dbjj.ide.api.exception.UnAuthorizedException;
+import goorm.dbjj.ide.domain.user.UserRepository;
+import goorm.dbjj.ide.domain.user.dto.User;
 import io.jsonwebtoken.Claims;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -11,6 +15,9 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+/**
+ * 토큰 자체를 인증하고, 권한 부여.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -18,6 +25,7 @@ public class JwtAuthProvider {
 
     private final UserDetailsService userDetailsService;
     private final JwtIssuer jwtIssuer;
+    private final UserRepository userRepository;
 
     // 토큰 인증
     public boolean validateToken(String token){
@@ -26,7 +34,10 @@ public class JwtAuthProvider {
             log.debug("validateToken() : 토큰이 비어있습니다.");
             return false;
         }
+
+        //jwt에 저장한 정보 추출 + 만료된 토큰인지 확인
         Claims claims = jwtIssuer.getClaims(token);
+
         if(claims == null){
             log.debug("validateToken() : 유저 정보가 비어있습니다.");
             return false;
@@ -34,13 +45,35 @@ public class JwtAuthProvider {
         return true;
     }
 
+    // refreshToken이 들어왔을 때, 토큰과 일치하는 user의 JWT 토큰 재발급.
+    @Transactional
+    public TokenInfo renewTokens(String refreshToken){
+
+        Claims claims = jwtIssuer.getClaims(refreshToken);
+        User user = userRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new UnAuthorizedException("토큰과 일치하는 유저가 없습니다."));
+
+        log.trace("{} <-> {}", user.getEmail(), claims.getSubject());
+
+        // 리프레시 토큰의 유저가 db에 있는지 확인.
+        if(!claims.getSubject().equals(user.getEmail())){
+            throw new UnAuthorizedException("회원 정보가 맞지 않습니다.");
+        }
+
+        // 새로운 토큰 발급.
+        TokenInfo newTokens = jwtIssuer.createToken(user.getEmail(), user.getRole().getKey());
+
+        // 유저 RefreshToken 업데이트.
+        user.updateRefreshToken(newTokens.getRefreshToken());
+
+        return newTokens;
+    }
+
     /**
      * JWT를 사용해서 사용자 인증 정보 추출, Authentication에 담기.
-     *  유저 정보가 비어있다면 exception.
      */
     public Authentication getAuthentication(String token){
-        Claims claims = jwtIssuer.getClaims(token);
-        String email = jwtIssuer.getSubject(claims);
+        String email = jwtIssuer.getSubject(jwtIssuer.getClaims(token));
         UserDetails userDetails = userDetailsService.loadUserByUsername(email);
 
         // 유저가 null 일 경우 exception

--- a/src/main/java/goorm/dbjj/ide/auth/jwt/JwtFilter.java
+++ b/src/main/java/goorm/dbjj/ide/auth/jwt/JwtFilter.java
@@ -1,6 +1,8 @@
 package goorm.dbjj.ide.auth.jwt;
 
 import goorm.dbjj.ide.api.exception.BaseException;
+import goorm.dbjj.ide.api.exception.UnAuthorizedException;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,13 +13,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.util.ObjectUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Base64;
 
 /**
  * 인증된 사용자인지 확인하는 filter
+ * OncePerRequestFilter: 요청마다 한번씩 실행되는 필터.
  */
 @Slf4j
 @Component
@@ -33,53 +36,91 @@ public class JwtFilter extends OncePerRequestFilter {
     private String refreshHeader;
 
     @Value("${app.exception-path}")
-    private static String EXCEPTION_PATH;
+    private String EXCEPTION_PATH;
+
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
     private final static String TOKEN_PREFIX = "Bearer ";
 
+    @PostConstruct
+    void init(){
+        // secretKey 한번 더 암호화.
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
-
-        String token = resolveTokenFromRequest(request);
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
 
         // EXCEPTION_PATH는 토큰 검사 안함.
         if(request.getRequestURI().equals(EXCEPTION_PATH)){
+            log.trace("이 페이지는 검사 안함 : {}", request.getRequestURI());
             filterChain.doFilter(request, response);
             return;
         }
 
-        // 토큰이 유효하면, 유저 정보 가져올 수 있게 저장.
-        if(isTokenValidAndRefixed(token)){
-            processTokenAuthentication(token);
+        String accessToken = request.getHeader(accessHeader);
+        String refreshToken = request.getHeader(refreshHeader);
+
+        /**
+         * 1. AccessToken이 들어오는 경우.
+         */
+        if(isTokenPrefixed(accessToken)){ // "Bearer "로 시작하는지 확인.
+
+            // 토큰만 추출. (Bearer 뒤에 부분)
+            accessToken = accessToken.substring(TOKEN_PREFIX.length());
+            log.trace("액세스 토큰 확인: {}", accessToken);
+
+            // 토큰이 만료되었는지 확인.
+            if (jwtAuthProvider.validateToken(accessToken)) {
+                // 유저 권한 부여.
+                Authentication auth = jwtAuthProvider.getAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
         }
 
+        /**
+         * 2. RefreshToken이 들어온 경우.
+         * Refresh 토큰이 유효하면 -> Access, Refresh 토큰 둘다 재발급.
+         */
+        else if(isTokenPrefixed(refreshToken)){ // "Bearer "로 시작하는지 확인.
+
+            // 토큰만 추출. (Bearer 뒤에 부분)
+            refreshToken = refreshToken.substring(TOKEN_PREFIX.length());
+            log.trace("리프레시 토큰 확인: {}", refreshToken);
+
+            // 토큰이 만료되었는지 확인.
+            if (!jwtAuthProvider.validateToken(refreshToken)){
+                throw new BaseException("유효하지 않는 토큰입니다.");
+            }
+
+            // 새로 발급 받은 토큰 -> response에 넘기기.
+            TokenInfo newTokens = jwtAuthProvider.renewTokens(refreshToken);
+
+            // 토큰을 response header에 담음.
+            response.setHeader(accessHeader, TOKEN_PREFIX + newTokens.getAccessToken());
+            response.setHeader(refreshHeader, TOKEN_PREFIX + newTokens.getRefreshToken());
+
+            // 인증된 사용자의 정보를 저장.
+            Authentication auth = jwtAuthProvider.getAuthentication(newTokens.getAccessToken());
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        /**
+         * 3. 토큰이 없는 경우.
+         */
+        else{
+            throw new UnAuthorizedException("토큰이 없거나 잘못된 토큰 정보 입니다.");
+        }
         filterChain.doFilter(request, response);
     }
 
-    private String resolveTokenFromRequest(HttpServletRequest request) {
-        String token = request.getHeader(accessHeader);
-
-        if (!ObjectUtils.isEmpty(token)) {
-            return token;
-        }
-        return null;
-    }
-
-    /**
-     * 토큰이 비어있지 않고, "Bearer "로 시작하는지 확인.
-     */
-    private boolean isTokenValidAndRefixed(String token){
+    // 토큰이 비어있지 않고, "Bearer "로 시작하는지 확인.
+    private boolean isTokenPrefixed(String token){
         return token != null && token.startsWith(TOKEN_PREFIX);
-    }
-
-    private void processTokenAuthentication(String token) {
-        token = token.substring(TOKEN_PREFIX.length());
-        log.trace("토큰 확인: {}", token);
-
-        if (jwtAuthProvider.validateToken(token)) {
-            Authentication auth = jwtAuthProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(auth);
-        }
     }
 }

--- a/src/main/java/goorm/dbjj/ide/auth/jwt/JwtIssuer.java
+++ b/src/main/java/goorm/dbjj/ide/auth/jwt/JwtIssuer.java
@@ -1,8 +1,6 @@
 package goorm.dbjj.ide.auth.jwt;
 
 import goorm.dbjj.ide.api.exception.BaseException;
-import goorm.dbjj.ide.domain.user.UserRepository;
-import goorm.dbjj.ide.domain.user.dto.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -15,12 +13,15 @@ import org.springframework.stereotype.Component;
 
 import java.util.Base64;
 import java.util.Date;
-import java.util.Optional;
 
+/**
+ * 토큰 생성.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtIssuer {
+
     @Value("${jwt.secretKey}")
     private String secretKey;
 
@@ -32,30 +33,13 @@ public class JwtIssuer {
 
     private static final String KEY_ROLES = "role";
 
-    private final UserRepository userRepository;
-
     // Base64 인코딩
     @PostConstruct
     void init(){
         secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
     }
 
-    // todo: refresh 토큰이 들어왔을 때, accessToken만 생성.
-    public String createToken(String refreshToken){
-        Optional<User> user = userRepository.findByRefreshToken(refreshToken);
-        User realUser = user.orElseThrow();
-
-        Claims claims = Jwts.claims().setSubject(realUser.getEmail());
-        claims.put(KEY_ROLES, "ROLE_USER");
-
-        Date now = new Date();
-        return Jwts.builder()
-                .setClaims(claims)
-                .setExpiration(new Date(now.getTime() + accessTokenExpirationPeriod))
-                .signWith(SignatureAlgorithm.HS256, secretKey)
-                .compact();
-    }
-
+    // JWT 토큰 생성.
     public TokenInfo createToken(String email, String role){
 
         Claims claims = Jwts.claims().setSubject(email);
@@ -83,11 +67,13 @@ public class JwtIssuer {
                 .build();
     }
 
+    // Claims에서 이메일 추출.
     public String getSubject(Claims claims){
         log.trace("이메일 : {}", claims.getSubject());
         return claims.getSubject();
     }
 
+    // token에 저장된 정보 가져오기.
     public Claims getClaims(String token){
         Claims claims;
         try{

--- a/src/main/java/goorm/dbjj/ide/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/goorm/dbjj/ide/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -73,7 +73,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         response.setStatus(HttpServletResponse.SC_OK);
 
         // 콘텐츠 타입 설정
-        response.setContentType("application/json");
+        response.setContentType("application/json; charset=UTF-8");
 
         User user = userRepository.findByEmail(oAuth2User.getEmail())
                 .orElseThrow(() -> new EntityNotFoundException("유저 정보가 없습니다."));
@@ -85,7 +85,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         responseMap.put("nickname", user.getNickname());
         responseMap.put("email", user.getEmail());
         responseMap.put("image_url", user.getImageUrl());
-        responseMap.put("created_at", user.getCreatedAt());
+        responseMap.put("created_at", user.getCreatedAt().toString());
 
         // Map을 Json 문자열로 변환
         String jsonResponse = mapper.writeValueAsString(responseMap);


### PR DESCRIPTION
**변경사항**
- JwtAuthProvider
  - 인증된 객체를 생성하기 전, 사용자의 세부 정보를 load하는데 세부 정보가 null이라면, exception 처리.
- OAuth2LoginSuccessHandler
  - 로그인 후 jwt를 헤더에 넣어서 보낼 때, response body에 유저 정보 같이 넣어서 전달.
- JwtIssuer
  - 불필요한 메서드 제거
  - 주석 추가
- JwtAuthProvider & JwtFilter
  - 리프레시 토큰이 들어오면, 유저 정보를 찾아서 JWT 재발행.