### PR TITLE
IDE-101 : Java, CPP 지원

### DIFF
--- a/src/main/java/goorm/dbjj/ide/container/ProgrammingLanguage.java
+++ b/src/main/java/goorm/dbjj/ide/container/ProgrammingLanguage.java
@@ -9,7 +9,9 @@ import java.util.List;
  */
 @Getter
 public enum ProgrammingLanguage {
-    PYTHON("python:3", List.of("python","-m","http.server","8000"));
+    PYTHON("python:3"),
+    JAVA("openjdk:11"),
+    CPP("gcc:latest");
 
     /**
      * Docker Hub에서 사용하는 이미지 이름
@@ -19,10 +21,8 @@ public enum ProgrammingLanguage {
     /**
      * 컨테이너가 실행될 때 실행할 명령어
      */
-    private final List<String> command;
 
-    ProgrammingLanguage(String image, List<String> command) {
+    ProgrammingLanguage(String image) {
         this.image = image;
-        this.command = command;
     }
 }

--- a/src/main/java/goorm/dbjj/ide/container/ProgrammingLanguage.java
+++ b/src/main/java/goorm/dbjj/ide/container/ProgrammingLanguage.java
@@ -18,10 +18,6 @@ public enum ProgrammingLanguage {
      */
     private final String image;
 
-    /**
-     * 컨테이너가 실행될 때 실행할 명령어
-     */
-
     ProgrammingLanguage(String image) {
         this.image = image;
     }

--- a/src/main/java/goorm/dbjj/ide/container/TaskDefinitionHelper.java
+++ b/src/main/java/goorm/dbjj/ide/container/TaskDefinitionHelper.java
@@ -39,7 +39,7 @@ public class TaskDefinitionHelper {
                 .networkMode(NetworkMode.AWSVPC)
                 .cpu("512")
                 .memory("1024")
-                .family("python")
+                .family(programmingLanguage.name())
                 .build();
     }
 
@@ -71,7 +71,7 @@ public class TaskDefinitionHelper {
                 .memory(1024)
                 .memoryReservation(1024)
                 .essential(true)
-                .command(programmingLanguage.getCommand())
+                .command("sleep", "infinity") //컨테이너가 무한히 대기
                 .linuxParameters(linux -> linux.initProcessEnabled(true))
                 .mountPoints(MOUNT_POINT)
                 .build();

--- a/src/test/java/goorm/dbjj/ide/container/ContainerUtilTest.java
+++ b/src/test/java/goorm/dbjj/ide/container/ContainerUtilTest.java
@@ -23,6 +23,9 @@ class ContainerUtilTest {
     @Autowired
     private ContainerUtil containerUtil;
 
+    @Autowired
+    private CommandStringBuilder commandStringBuilder;
+
     @Test
     @Disabled
     void createContainerImage() {
@@ -77,12 +80,12 @@ class ContainerUtilTest {
     void executeCommand() {
 
         //given
-        String containerId = "arn:aws:ecs:ap-northeast-2:092624380570:task/IDE_CONTAINER/d30bf40102a74406bd51420d5a1e6589";
-        String command = "python hello.py";
+        String containerId = "arn:aws:ecs:ap-northeast-2:092624380570:task/IDE_CONTAINER/ae756009ce644ed6a3e3a00e136a2c1f";
+        String command = "javac Main.java && java Main";
         String path = "/";
-        String projectId = "";
+        String projectId = "ea90e9ad-3b48-459f-a460-15a762b2cb15";
         Long userId = 1L;
-        String createdCommand = new CommandStringBuilder().createCommand(path, command, projectId, userId);
+        String createdCommand = commandStringBuilder.createCommand(path, command, projectId, userId);
         //when
         containerUtil.executeCommand(containerId, createdCommand);
     }


### PR DESCRIPTION
기능 변경
* 도커 컨테이너가 꺼지지 않게 유지한 기존의 방식 (http 서버 키기)를 sleep infinity라는 linux 명령어로 변경했습니다.
* 이제 JAVA와 CPP 컨테이너를 생성할 수 있습니다.