### PR TITLE
IDE-98 websocket module 동시접속 안되는 오류 해결

### DIFF
--- a/src/main/java/goorm/dbjj/ide/websocket/WebSocketChannelInterceptor.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/WebSocketChannelInterceptor.java
@@ -97,11 +97,9 @@ public class WebSocketChannelInterceptor implements ChannelInterceptor {
                 throw new BaseException("웹소켓에 연결될 프로젝트가 존재하지 않습니다.");
             }
 
-            // 이미 실행중인 프로젝트인지 검증
-            if (webSocketUserSessionMapper.existsByProjectAndUser(userInfoDto, projectId)) {
-                log.warn("이미 실행중인 프로젝트 입니다.");
-                throw new BaseException("이미 실행중인 프로젝트 입니다!");
-            }
+            // 동시접속 막는 로직 : 프로젝트가 참여한 유저인지 검증 로직
+            webSocketUserSessionMapper.existsByProjectAndUser(userInfoDto, projectId);
+
             // 세션등록
             String sessionId = getSessionId(headerAccessor);
             webSocketUserSessionMapper.put(sessionId, new WebSocketUser(userInfoDto, projectId));

--- a/src/main/java/goorm/dbjj/ide/websocket/WebSocketEventListener.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/WebSocketEventListener.java
@@ -1,6 +1,5 @@
 package goorm.dbjj.ide.websocket;
 
-import goorm.dbjj.ide.api.exception.BaseException;
 import goorm.dbjj.ide.websocket.chatting.ChatsService;
 import goorm.dbjj.ide.websocket.chatting.dto.ChattingResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -41,16 +40,15 @@ public class WebSocketEventListener {
         // WebSocketUserSessionMapper 없애기
         WebSocketUser removeWebSocketUser = webSocketUserSessionMapper.remove(uuid);
         if(removeWebSocketUser == null){
-            log.warn("WebSocketChannelInterceptor.preSend 잘못된 사용자 접근입니다.");
-            throw new BaseException("잘못된 사용자 접근");
-        }
-
-        // 퇴장 메세지 출력
-        String nickname = removeWebSocketUser.getUserInfoDto().getNickname();
-        String projectId = removeWebSocketUser.getProjectId();
-        Optional<ChattingResponseDto> exitMessage = chatsService.exit(nickname, projectId);
-        if(exitMessage.isPresent()) {
-            template.convertAndSend("/topic/project/"+ projectId + "/chat", exitMessage);
+            log.warn("WebSocketEventListener.handleWebSocketDisconnectListener 웹소켓을 종료하고자 하는 사용자가 없습니다.");
+        } else {
+            // 퇴장 메세지 출력
+            String nickname = removeWebSocketUser.getUserInfoDto().getNickname();
+            String projectId = removeWebSocketUser.getProjectId();
+            Optional<ChattingResponseDto> exitMessage = chatsService.exit(nickname, projectId);
+            if (exitMessage.isPresent()) {
+                template.convertAndSend("/topic/project/" + projectId + "/chat", exitMessage);
+            }
         }
     }
 }

--- a/src/main/java/goorm/dbjj/ide/websocket/WebSocketUserSessionMapper.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/WebSocketUserSessionMapper.java
@@ -1,5 +1,6 @@
 package goorm.dbjj.ide.websocket;
 
+import goorm.dbjj.ide.api.exception.BaseException;
 import goorm.dbjj.ide.websocket.dto.UserInfoDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -37,8 +38,12 @@ public class WebSocketUserSessionMapper {
      * 실행중인 프로젝트인지 확인하는 로직
      * @return true:이미 존재함, false: 존재안함
      * */
-    public boolean existsByProjectAndUser(UserInfoDto userInfoDto, String projectId) {
-        return webSocketUserSessionMap.contains(new WebSocketUser(userInfoDto, projectId));
+    public void existsByProjectAndUser(UserInfoDto userInfoDto, String projectId) {
+        if(webSocketUserSessionMap.values().stream()
+                .anyMatch(w ->  w.getProjectId().equals(projectId) && w.getUserInfoDto().getId().equals(userInfoDto.getId()))){
+            log.warn("이미 실행중인 프로젝트 입니다.");
+            throw new BaseException("이미 실행중인 프로젝트 입니다!");
+        }
     }
 
     /**

--- a/src/main/java/goorm/dbjj/ide/websocket/WebSocketUserSessionMapper.java
+++ b/src/main/java/goorm/dbjj/ide/websocket/WebSocketUserSessionMapper.java
@@ -53,7 +53,6 @@ public class WebSocketUserSessionMapper {
     public String findSessionIdByProjectAndUserInfoDto(Long userId, String projectId) {
         return webSocketUserSessionMap.entrySet()
                 .stream()
-//                .filter(entry -> new WebSocketUser(userInfoDto, projectId).equals(entry.getValue()))
                 .filter(entry -> entry.getValue().isSameWith(userId, projectId))
                 .map(Map.Entry::getKey)
                 .findFirst()


### PR DESCRIPTION
변경사항
-  기존 동시 접속 로직은 객체 생성 후 equals hashcode 로 비교 하는 것이였음 => equals hashcode 가 없는 문제였습니다.
-  그래서 객체생성말고 Mapper의 value를 조사해여 일치하는 userId, projectId가 있는지 확인하는 로직으로 변경했습니다.
- disconnect 시 동시접속등 오류로 인하여 종료 될때도 Mapper를 검사해서 exception을 터트리는 불필요한 로직 삭제
  - 디버깅이 더 편해짐

특이사항
- 테스트 결과 잘 동작하였습니다.