### PR TITLE
hotfix:FileWatcher가 논리적 주소 앞 / 추가

### DIFF
--- a/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcher.java
+++ b/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcher.java
@@ -122,7 +122,7 @@ public class FileWatcher {
      */
     private String extractLogicalAddress(String path, String projectId) {
         try {
-            return path.substring(path.indexOf(projectId) + projectId.length() + 1);
+            return path.substring(path.indexOf(projectId) + projectId.length());
         } catch (Exception e) {
             return null;
         }


### PR DESCRIPTION
상대주소가 / 를 포함합니다.