### PR TITLE
 IDE-109 User 반환 API 응답값 ApiResponse로 변경

### DIFF
--- a/src/main/java/goorm/dbjj/ide/domain/user/UserController.java
+++ b/src/main/java/goorm/dbjj/ide/domain/user/UserController.java
@@ -1,14 +1,14 @@
 package goorm.dbjj.ide.domain.user;
 
+import goorm.dbjj.ide.api.ApiResponse;
 import goorm.dbjj.ide.domain.user.dto.User;
-import org.springframework.http.ResponseEntity;
+import goorm.dbjj.ide.domain.user.dto.UserDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
-import java.util.Map;
-
+@Slf4j
 @RestController
 public class UserController {
 
@@ -21,16 +21,8 @@ public class UserController {
     }
 
     @GetMapping("/user/info")
-    public ResponseEntity<Map<String, Object>> getUserInfo(@AuthenticationPrincipal User user){
-
-        Map<String, Object> responseMap = new HashMap<>();
-
-        responseMap.put("id", user.getId());
-        responseMap.put("nickname", user.getNickname());
-        responseMap.put("email", user.getEmail());
-        responseMap.put("image_url", user.getImageUrl());
-        responseMap.put("created_at", user.getCreatedAt().toString());
-
-        return ResponseEntity.ok(responseMap);
+    public ApiResponse<UserDto> getUserInfo(@AuthenticationPrincipal User user){
+        log.trace("UserController.getUserInfo() called");
+        return ApiResponse.ok(UserDto.of(user));
     }
 }

--- a/src/main/java/goorm/dbjj/ide/domain/user/dto/UserDto.java
+++ b/src/main/java/goorm/dbjj/ide/domain/user/dto/UserDto.java
@@ -1,0 +1,25 @@
+package goorm.dbjj.ide.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class UserDto {
+    private Long id;
+    private String nickname;
+    private String email;
+    private String imageUrl;
+    private LocalDateTime createdAt;
+
+    public static UserDto of(User user){
+        return new UserDto(
+                user.getId(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getImageUrl(),
+                user.getCreatedAt());
+    }
+}


### PR DESCRIPTION
기능 변경
* 유저 정보 반환 API에서 기존의 ResponseEntity를 사용하는 방식에서 ApiResponse로 사용하는 방식으로 바꿨습니다.
* UserDto를 만들었습니다.