### PR TITLE
IDE-129: logical directory extractor

### DIFF
--- a/src/main/java/goorm/dbjj/ide/lambdahandler/executionoutput/LogicalDirectoryExtractor.java
+++ b/src/main/java/goorm/dbjj/ide/lambdahandler/executionoutput/LogicalDirectoryExtractor.java
@@ -1,0 +1,15 @@
+package goorm.dbjj.ide.lambdahandler.executionoutput;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * 도커의 디렉터리 구조로부터 프로젝트 상대 디렉터리 주소를 추출합니다.
+ */
+@Component
+public class LogicalDirectoryExtractor {
+
+    public String extract(String path) {
+        String logicalDirectory = path.substring(path.indexOf("/app")+ 4);
+        return logicalDirectory.isEmpty() ? "/" : logicalDirectory;
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/lambdahandler/executionoutput/OutputSendingServiceImpl.java
+++ b/src/main/java/goorm/dbjj/ide/lambdahandler/executionoutput/OutputSendingServiceImpl.java
@@ -32,8 +32,7 @@ public class OutputSendingServiceImpl implements OutputSendingService {
     }
 
     /**
-     * 이 private 메서드로 인해 테스트가 어려워지는 문제 발생
-     * 추후 분리 예정
+     * 메시지를 파싱합니다.
      * @param message
      * @return
      */

--- a/src/main/java/goorm/dbjj/ide/lambdahandler/executionoutput/OutputSendingServiceImpl.java
+++ b/src/main/java/goorm/dbjj/ide/lambdahandler/executionoutput/OutputSendingServiceImpl.java
@@ -15,6 +15,7 @@ public class OutputSendingServiceImpl implements OutputSendingService {
     private String separator;
 
     private final TerminalController terminalController;
+    private final LogicalDirectoryExtractor extractor;
 
     @Override
     public void sendTo(String executionOutput, String projectId, Long userId) {
@@ -45,19 +46,9 @@ public class OutputSendingServiceImpl implements OutputSendingService {
         }
 
         return switch (splitedMessage.length) {
-            case 1 -> new ExecutionOutputDto(true, "", extractLogicalAddress(splitedMessage[0]));
-            case 2 -> new ExecutionOutputDto(true, splitedMessage[0], extractLogicalAddress(splitedMessage[1]));
+            case 1 -> new ExecutionOutputDto(true, "", extractor.extract(splitedMessage[0]));
+            case 2 -> new ExecutionOutputDto(true, splitedMessage[0], extractor.extract(splitedMessage[1]));
             default -> new ExecutionOutputDto(false, "알 수 없는 오류가 발생했습니다.", "");
         };
-    }
-
-    /**
-     * 도커 path에서 사용자의 상대 주소를 추출합니다.
-     * @param path
-     * @return
-     */
-    private String extractLogicalAddress(String path) {
-        String logicalDirectory = path.substring(path.indexOf("/app")+ 4);
-        return logicalDirectory.isEmpty() ? "/" : logicalDirectory;
     }
 }

--- a/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcher.java
+++ b/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatcher.java
@@ -27,6 +27,8 @@ public class FileWatcher {
 
     private final WebSocketFileDirectoryController webSocketFileDirectoryController;
 
+    private final String EXCEPT_FILE = ".*\\.swp";
+
     public void watch(String dir) throws Exception {
 
         FileAlterationObserver observer = new FileAlterationObserver(dir);
@@ -53,17 +55,32 @@ public class FileWatcher {
                 sendToUser(DELETE, directory);
             }
 
+            @Override
+            public void onFileChange(File file) {
+                /*
+                File Change에 대해서는 별도로 알리지 않아도 됩니다.
+                 */
+            }
+
             /**
              * 현재 swap 파일의 생성 역시 감지되는 이슈가 있습니다.
              * @param file The file created (ignored)
              */
             @Override
             public void onFileCreate(File file) {
+                if (file.getName().matches(EXCEPT_FILE)) {
+                    return;
+                }
+
                 sendToUser(CREATE, file);
             }
 
             @Override
             public void onFileDelete(File file) {
+                if (file.getName().matches(EXCEPT_FILE)) {
+                    return;
+                }
+
                 sendToUser(DELETE, file);
             }
 
@@ -122,6 +139,7 @@ public class FileWatcher {
 
     /**
      * EFS 스토리지의 디렉터리 경로에서 논리적 주소를 추출합니다.
+     *
      * @param path
      * @return
      */

--- a/src/test/java/goorm/dbjj/ide/fileDirectory/FileIoProjectFileServiceTest.java
+++ b/src/test/java/goorm/dbjj/ide/fileDirectory/FileIoProjectFileServiceTest.java
@@ -130,14 +130,14 @@ public class FileIoProjectFileServiceTest {
     void noFile() {
         assertThatThrownBy (
                 () -> projectFileService.loadFile("project1","/hello2.py")
-        ).isInstanceOf(BaseException.class).hasMessage("파일 load 실패 Path: /hello2.py");
+        ).isInstanceOf(BaseException.class).hasMessage("load 실패 Path: /hello2.py");
     }
 
     @Test
     void noDirectory() {
         assertThatThrownBy(
                 () -> projectFileService.loadFile("project2","/hi")
-        ).isInstanceOf(BaseException.class).hasMessage("파일 load 실패 Path: /hi");
+        ).isInstanceOf(BaseException.class).hasMessage("load 실패 Path: /hi");
     }
 
     @Test

--- a/src/test/java/goorm/dbjj/ide/lambdahandler/executionoutput/LogicalDirectoryExtractorTest.java
+++ b/src/test/java/goorm/dbjj/ide/lambdahandler/executionoutput/LogicalDirectoryExtractorTest.java
@@ -1,0 +1,24 @@
+package goorm.dbjj.ide.lambdahandler.executionoutput;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class LogicalDirectoryExtractorTest {
+
+    private LogicalDirectoryExtractor extractor = new LogicalDirectoryExtractor();
+    @Test
+    void extractRoot() {
+        String path = "/app";
+        String extractedPath = extractor.extract(path);
+        assertThat(extractedPath).isEqualTo("/");
+    }
+
+    @Test
+    void extract() {
+        String path = "/app/src/hello.py";
+        String extractedPath = extractor.extract(path);
+        assertThat(extractedPath).isEqualTo("/src/hello.py");
+    }
+
+}

--- a/src/test/java/goorm/dbjj/ide/lambdahandler/outputsending/OutputSendingServiceImplTest.java
+++ b/src/test/java/goorm/dbjj/ide/lambdahandler/outputsending/OutputSendingServiceImplTest.java
@@ -26,7 +26,8 @@ class OutputSendingServiceImplTest {
         }
     }
     OutputSendingService outputSendingService = new OutputSendingServiceImpl(
-            new MockTerminalController()
+            new MockTerminalController(),
+            new LogicalDirectoryExtractor()
     );
 
     @Value("${app.outputSeparator}")


### PR DESCRIPTION
기능 변경
* 기존 OutputSendingService의 private method로 존재했던 logical address 분리하는 메서드를 별도의 클래스로 분리했습니다. -> (테스트 코드 작성에 어려움이 있어서)
* 논리적 주소 추출하는 클래스의 테스트 코드를 작성했습니다.