### PR TITLE
feature/IDE-130-FileDto-파일-생성-누락-해결

### DIFF
--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/ProjectFileController.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/ProjectFileController.java
@@ -41,6 +41,7 @@ public class ProjectFileController {
         );
 
         FileResponseDto responseDto = FileResponseDto.builder()
+                .id(file.getId())
                 .filePath(file.getFilePath())
                 .fileName(file.getFileName())
                 .content(file.getContent()).build();


### PR DESCRIPTION
파일 DTO에 ID가 누락되는 경우를 해결했습니다.