### PR TITLE
IDE-130: ID를 관리할 수 있는 파일 서비스 제공

### DIFF
--- a/src/main/java/goorm/dbjj/ide/api/GlobalRestControllerAdvice.java
+++ b/src/main/java/goorm/dbjj/ide/api/GlobalRestControllerAdvice.java
@@ -3,6 +3,7 @@ package goorm.dbjj.ide.api;
 import goorm.dbjj.ide.api.exception.BaseException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -25,6 +26,13 @@ public class GlobalRestControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(BaseException.class)
     public ApiResponse<String> handleBaseException(BaseException e) {
+        log.debug("Exception catched in RestControllerAdvice : {}",e.getMessage());
+        return ApiResponse.fail(e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
         log.debug("Exception catched in RestControllerAdvice : {}",e.getMessage());
         return ApiResponse.fail(e.getMessage());
     }

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/ExceptionHandleAspect.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/ExceptionHandleAspect.java
@@ -1,0 +1,50 @@
+package goorm.dbjj.ide.domain.fileDirectory.id;
+
+import goorm.dbjj.ide.api.exception.BaseException;
+import goorm.dbjj.ide.storageManager.exception.CustomIOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import static goorm.dbjj.ide.storageManager.StorageManager.RESOURCE_SEPARATOR;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandleAspect {
+
+    @Value("${app.efs-root-directory}")
+    private String ROOT_DIRECTORY;
+
+    private String getRelativePath(String fullPath) {
+        if (fullPath != null && fullPath.startsWith(ROOT_DIRECTORY)) {
+            String withoutRoot = fullPath.substring(ROOT_DIRECTORY.length());
+            return withoutRoot.startsWith(RESOURCE_SEPARATOR) ? // root 가 '/' 로 시작하는지 확인
+                    withoutRoot.substring(withoutRoot.indexOf(RESOURCE_SEPARATOR, 1)) : withoutRoot;
+        }
+        return fullPath;
+    }
+
+    //CustomIOException 을 상속받은 예외들을 처리하는 Aspect
+
+    //포인트컷 지정자?
+    @Around("execution(* goorm.dbjj.ide.domain.fileDirectory.id.IdManagedProjectFileService.*(..))")
+    public Object handleCustomIOException(ProceedingJoinPoint joinPoint) {
+        log.trace(joinPoint.getSignature().getName());
+
+        try {
+            return joinPoint.proceed();
+
+        } catch (CustomIOException e) {
+            throw new BaseException(e.getModel().getMessage() + " Path: " + getRelativePath(e.getModel().getPath()));
+        } catch (Throwable throwable) {
+            throw new BaseException(throwable.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/FileMetadata.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/FileMetadata.java
@@ -1,0 +1,40 @@
+package goorm.dbjj.ide.domain.fileDirectory.id;
+
+import goorm.dbjj.ide.domain.project.model.Project;
+import goorm.dbjj.ide.storageManager.model.ResourceType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class FileMetadata {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    private String path;
+
+    @Enumerated(EnumType.STRING)
+    ResourceType type;
+
+    public FileMetadata(Project project, String path, ResourceType type) {
+        this.project = project;
+        this.path = path;
+        this.type = type;
+    }
+
+    public String getProjectId() {
+        return project.getId();
+    }
+
+    public void changePath(String path) {
+        this.path = path;
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/FileMetadataRepository.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/FileMetadataRepository.java
@@ -1,0 +1,11 @@
+package goorm.dbjj.ide.domain.fileDirectory.id;
+
+import goorm.dbjj.ide.domain.project.model.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long> {
+
+    List<FileMetadata> findByProject(Project project);
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/FileMetadataRepository.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/FileMetadataRepository.java
@@ -4,8 +4,11 @@ import goorm.dbjj.ide.domain.project.model.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FileMetadataRepository extends JpaRepository<FileMetadata, Long> {
 
     List<FileMetadata> findByProject(Project project);
+
+    Optional<FileMetadata> findByProjectIdAndPath(String projectId, String path);
 }

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/IdManagedFileController.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/IdManagedFileController.java
@@ -1,0 +1,110 @@
+package goorm.dbjj.ide.domain.fileDirectory.id;
+
+import goorm.dbjj.ide.api.ApiResponse;
+import goorm.dbjj.ide.domain.fileDirectory.UserProjectValidator;
+import goorm.dbjj.ide.domain.fileDirectory.id.model.IdManagedDirectoryCreateRequestDto;
+import goorm.dbjj.ide.domain.fileDirectory.id.model.IdManagedFileCreateRequestDto;
+import goorm.dbjj.ide.domain.fileDirectory.id.model.IdManagedFileDeleteRequestDto;
+import goorm.dbjj.ide.domain.fileDirectory.id.model.IdManagedFileUpdateRequestDto;
+import goorm.dbjj.ide.domain.user.dto.User;
+import goorm.dbjj.ide.model.dto.FileResponseDto;
+import goorm.dbjj.ide.storageManager.exception.CustomIOException;
+import goorm.dbjj.ide.storageManager.model.ResourceDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2")
+public class IdManagedFileController {
+
+    private final IdManagedProjectFileService projectFileService;
+    @PostMapping("/files")
+    public ApiResponse<Long> createFile(
+            @Validated @RequestBody IdManagedFileCreateRequestDto dto,
+            @AuthenticationPrincipal User user
+    ) throws CustomIOException {
+        Long createdId = projectFileService.createFile(
+                dto.getProjectId(),
+                dto.getPath()
+        );
+
+        return ApiResponse.ok(createdId, "파일 생성 성공");
+    }
+
+    @PostMapping("/directories")
+    public ApiResponse<Long> createDirectory(
+            @Validated @RequestBody IdManagedDirectoryCreateRequestDto dto,
+            @AuthenticationPrincipal User user
+    ) throws CustomIOException {
+
+        Long createdId = projectFileService.createDirectory(
+                dto.getProjectId(),
+                dto.getPath()
+        );
+
+        return ApiResponse.ok(createdId, "디렉토리 생성 성공");
+    }
+
+    @PutMapping("/files")
+    public ApiResponse<String> changeFile(
+            @Validated @RequestBody IdManagedFileUpdateRequestDto dto,
+            @AuthenticationPrincipal User user
+    ) throws CustomIOException {
+        projectFileService.changeFile(
+                dto.getFileId(),
+                dto.getPath(),
+                dto.getContent()
+        );
+
+        return ApiResponse.ok("파일 변경 성공");
+    }
+
+    @DeleteMapping("/files/{fileId}")
+    public ApiResponse<String> deleteFile(
+            @PathVariable Long fileId,
+            @AuthenticationPrincipal User user
+    ) throws CustomIOException {
+        projectFileService.deleteFile(
+                fileId
+        );
+
+        return ApiResponse.ok("파일 삭제 성공");
+    }
+
+    @DeleteMapping("/directories/{directoryId}")
+    public ApiResponse<String> deleteDirectory(
+            @PathVariable Long directoryId,
+            @AuthenticationPrincipal User user
+    ) throws CustomIOException {
+        projectFileService.deleteDirectory(
+                directoryId
+        );
+
+        return ApiResponse.ok("디렉토리 삭제 성공");
+    }
+
+    @GetMapping("/files/{fileId}")
+    public ApiResponse<FileResponseDto> getFile(
+            @PathVariable Long fileId,
+            @AuthenticationPrincipal User user
+    ) throws CustomIOException {
+        FileResponseDto dto = projectFileService.loadFile(fileId);
+        return ApiResponse.ok(dto);
+    }
+
+    @GetMapping("/projects/{projectId}/directory")
+    public ApiResponse<List<ResourceDto>> loadProjectDirectory(
+            @PathVariable String projectId,
+            @AuthenticationPrincipal User user
+    ) throws CustomIOException {
+        List<ResourceDto> resourceDtos = projectFileService.loadDirectory(projectId);
+        return ApiResponse.ok(resourceDtos);
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/IdManagedProjectFileService.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/IdManagedProjectFileService.java
@@ -1,0 +1,267 @@
+package goorm.dbjj.ide.domain.fileDirectory.id;
+
+import goorm.dbjj.ide.api.exception.BaseException;
+import goorm.dbjj.ide.domain.fileDirectory.id.model.PathGenerator;
+import goorm.dbjj.ide.domain.project.ProjectRepository;
+import goorm.dbjj.ide.domain.project.model.Project;
+import goorm.dbjj.ide.model.dto.FileResponseDto;
+import goorm.dbjj.ide.storageManager.StorageManager;
+import goorm.dbjj.ide.storageManager.exception.CustomIOException;
+import goorm.dbjj.ide.storageManager.model.Resource;
+import goorm.dbjj.ide.storageManager.model.ResourceDto;
+import goorm.dbjj.ide.storageManager.model.ResourceType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static goorm.dbjj.ide.storageManager.StorageManager.RESOURCE_SEPARATOR;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class IdManagedProjectFileService {
+
+    private final StorageManager storageManager;
+    private final FileMetadataRepository fileMetadataRepository;
+    private final ProjectRepository projectRepository;
+    private final PathGenerator pathGenerator;
+
+    @Value("${app.efs-root-directory}")
+    private String ROOT_DIRECTORY;
+
+    private String getRelativePath(String fullPath) {
+        if (fullPath != null && fullPath.startsWith(ROOT_DIRECTORY)) {
+            String withoutRoot = fullPath.substring(ROOT_DIRECTORY.length());
+            return withoutRoot.startsWith(RESOURCE_SEPARATOR) ? // root 가 '/' 로 시작하는지 확인
+                    withoutRoot.substring(withoutRoot.indexOf(RESOURCE_SEPARATOR, 1)) : withoutRoot;
+        }
+        return fullPath;
+    }
+
+    //파일을 생성한다.
+    //파일이 이미 존재하는가? -> 직접 검증
+    //파일을 생성할 수 있는 위치인가? -> saveFile에서 검증
+    public Long createFile(String projectId, String path) throws CustomIOException {
+
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BaseException("해당 프로젝트가 존재하지 않습니다."));
+
+        if (storageManager.exists(pathGenerator.getPath(projectId, path))) {
+            throw new BaseException("해당 위치에 파일이 이미 존재합니다.");
+        }
+
+
+        storageManager.saveFile(pathGenerator.getPath(projectId, path), "");
+
+        FileMetadata savedFileMetadata = fileMetadataRepository.save(new FileMetadata(project, path, ResourceType.FILE));
+
+        return savedFileMetadata.getId();
+    }
+
+
+    /**
+     * 디렉터리를 생성합니다.
+     * <p>
+     * 디렉터리가 이미 존재하나?
+     * 디렉터리를 생성할 수 있는 위치인가?
+     *
+     * @param projectId
+     * @param path
+     * @return
+     */
+    public Long createDirectory(String projectId, String path) throws CustomIOException {
+
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BaseException("해당 프로젝트가 존재하지 않습니다."));
+
+        if (storageManager.exists(ROOT_DIRECTORY + "/" + projectId + path)) {
+            throw new BaseException("해당 위치에 파일이 이미 존재합니다.");
+        }
+
+        storageManager.createDirectory(pathGenerator.getPath(projectId, path));
+
+        FileMetadata savedFileMetadata = fileMetadataRepository.save(
+                new FileMetadata(project, path, ResourceType.DIRECTORY)
+        );
+
+        return savedFileMetadata.getId();
+    }
+
+    public List<ResourceDto> loadDirectory(String projectId) throws CustomIOException {
+
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BaseException("해당 프로젝트가 존재하지 않습니다."));
+
+        List<FileMetadata> fileMetadatas = fileMetadataRepository.findByProject(project);
+
+        Resource resource = storageManager.loadDirectory(ROOT_DIRECTORY + "/" + projectId);
+
+        return convertResourceListToDtoList(resource.getChildren(), ROOT_DIRECTORY + "/" + projectId, fileMetadatas);
+    }
+
+    /**
+     * 파일을 수정합니다.
+     * <p>
+     * 수정할 파일이 존재하는가?
+     * 수정할 파일이 디렉터리인가?
+     * 수정될 위치에 파일이 존재하는가?
+     *
+     * @param fileId
+     * @param path
+     * @param content
+     */
+    public void changeFile(Long fileId, String path, String content) throws CustomIOException {
+
+        FileMetadata fileMetadata = fileMetadataRepository.findById(fileId)
+                .orElseThrow(() -> new BaseException("해당 파일이 존재하지 않습니다.:FileMetadata"));
+
+        File originFile = new File(pathGenerator.getPath(fileMetadata));
+        if (!originFile.exists()) {
+            throw new BaseException("삭제하려는 파일이 존재하지 않습니다.:File ");
+        }
+
+        if (fileMetadata.getType().equals(ResourceType.DIRECTORY)) {
+            throw new BaseException("디렉토리를 변경하려고 합니다.");
+        }
+
+        File tmp = new File(pathGenerator.getPath(fileMetadata.getProjectId(), path));
+
+        if (tmp.exists() && !fileMetadata.getPath().equals(path)) {
+            throw new BaseException("해당 위치에 파일이 이미 존재합니다.");
+        }
+
+
+        storageManager.deleteFile(pathGenerator.getPath(fileMetadata));
+        storageManager.saveFile(
+                pathGenerator.getPath(
+                        fileMetadata.getProjectId(),
+                        path
+                ),
+                content
+        );
+
+        fileMetadata.changePath(path);
+    }
+
+    /**
+     * 파일을 삭제합니다.
+     * <p>
+     * 삭제할 파일이 존재하는가?
+     * 삭제할 파일이 디렉터리인가?
+     *
+     * @param fileId
+     */
+    public void deleteFile(Long fileId) throws CustomIOException {
+
+        FileMetadata fileMetadata = fileMetadataRepository.findById(fileId)
+                .orElseThrow(() -> new BaseException("해당 파일이 존재하지 않습니다."));
+
+        File originFile = new File(pathGenerator.getPath(fileMetadata));
+        if (!originFile.exists()) {
+            throw new BaseException("삭제하려는 파일이 존재하지 않습니다.");
+        }
+
+        if (fileMetadata.getType().equals(ResourceType.DIRECTORY)) {
+            throw new BaseException("디렉토리를 삭제하려고 합니다.");
+        }
+
+        storageManager.deleteFile(pathGenerator.getPath(fileMetadata));
+        fileMetadataRepository.delete(fileMetadata);
+    }
+
+    /**
+     * 디렉터리를 삭제합니다.
+     * <p>
+     * 삭제할 디렉터리가 존재하는가?
+     * 삭제할 디렉터리가 파일인가?
+     *
+     * @param fileId
+     */
+    public void deleteDirectory(Long fileId) throws CustomIOException {
+
+        FileMetadata fileMetadata = fileMetadataRepository.findById(fileId)
+                .orElseThrow(() -> new BaseException("해당 폴더가 존재하지 않습니다."));
+
+        File originFile = new File(pathGenerator.getPath(fileMetadata));
+        if (!originFile.exists()) {
+            throw new BaseException("삭제하려는 폴더가 존재하지 않습니다.");
+        }
+
+        if (fileMetadata.getType().equals(ResourceType.FILE)) {
+            throw new BaseException("파일을 삭제하려고 합니다.");
+        }
+
+        storageManager.deleteFile(pathGenerator.getPath(fileMetadata));
+        fileMetadataRepository.delete(fileMetadata);
+    }
+
+    public FileResponseDto loadFile(Long fileId) throws CustomIOException {
+
+        FileMetadata fileMetadata = fileMetadataRepository.findById(fileId)
+                .orElseThrow(() -> new BaseException("해당 파일이 존재하지 않습니다."));
+
+        if (fileMetadata.getType().equals(ResourceType.DIRECTORY)) {
+            throw new BaseException("디렉토리를 불러오려고 합니다.");
+        }
+
+        Resource resource = storageManager.loadFile(ROOT_DIRECTORY + "/" + fileMetadata.getProject().getId() + fileMetadata.getPath());
+        return new FileResponseDto(
+                fileMetadata.getId(),
+                fileMetadata.getPath(),
+                resource.getName(),
+                resource.getContent()
+        );
+    }
+
+    private List<ResourceDto> convertResourceListToDtoList(
+            List<Resource> resources,
+            String parentPath,
+            List<FileMetadata> metadatas
+    ) {
+        List<ResourceDto> resourceDtos = new ArrayList<>();
+        if (resources != null) {
+            for (Resource resource : resources) {
+                String resourceFullPath = parentPath + RESOURCE_SEPARATOR + resource.getName();
+                resourceDtos.add(convertResourceToResourceDto(resource, resourceFullPath, metadatas));
+            }
+        }
+        return resourceDtos;
+    }
+
+    private ResourceDto convertResourceToResourceDto(Resource resource, String
+            fullPath, List<FileMetadata> metadatas) {
+        List<ResourceDto> childDtos = null;
+        String relationPath = getRelativePath(fullPath);
+
+        if (resource.isDirectory()) {
+            childDtos = new ArrayList<>();
+            if (resource.getChildren() != null) {
+                for (Resource child : resource.getChildren()) {
+                    String childFullPath = fullPath + RESOURCE_SEPARATOR + child.getName();
+                    String childRelativePath = getRelativePath(fullPath);
+                    childDtos.add(convertResourceToResourceDto(child, childFullPath, metadatas));
+                }
+            }
+        }
+        String relativePath = getRelativePath(fullPath);
+
+        Long id = metadatas.stream().filter(metadata -> metadata.getPath().equals(relativePath)).findFirst().get().getId();
+
+        return ResourceDto.builder()
+                .id(id)
+                .name(resource.getName())
+                .type(resource.getResourceType().toString())
+                .children(childDtos)
+                .path(relativePath)
+                .build();
+    }
+
+
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedDirectoryCreateRequestDto.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedDirectoryCreateRequestDto.java
@@ -1,0 +1,19 @@
+package goorm.dbjj.ide.domain.fileDirectory.id.model;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class IdManagedDirectoryCreateRequestDto {
+
+    @NotNull
+    private String projectId;
+
+    //it should start with "/"
+    @NotNull(message = "Path에 null이 들어오면 안됩니다.")
+    @Pattern(regexp = "^/.*", message = "Path는 /로 시작해야 합니다.")
+    private String path;
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedDirectoryDeleteRequestDto.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedDirectoryDeleteRequestDto.java
@@ -1,0 +1,13 @@
+package goorm.dbjj.ide.domain.fileDirectory.id.model;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class IdManagedDirectoryDeleteRequestDto {
+
+    @NotNull
+    private Long directoryId;
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedFileCreateRequestDto.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedFileCreateRequestDto.java
@@ -1,0 +1,19 @@
+package goorm.dbjj.ide.domain.fileDirectory.id.model;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class IdManagedFileCreateRequestDto {
+
+    @NotNull
+    private String projectId;
+
+    //it should start with "/"
+    @Pattern(regexp = "^/.*", message = "Path는 /로 시작해야 합니다.")
+    @NotNull(message = "Path에 null이 들어오면 안됩니다.")
+    private String path;
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedFileDeleteRequestDto.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedFileDeleteRequestDto.java
@@ -1,0 +1,12 @@
+package goorm.dbjj.ide.domain.fileDirectory.id.model;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class IdManagedFileDeleteRequestDto {
+    @NotNull
+    private Long fileId;
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedFileUpdateRequestDto.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/IdManagedFileUpdateRequestDto.java
@@ -1,0 +1,22 @@
+package goorm.dbjj.ide.domain.fileDirectory.id.model;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class IdManagedFileUpdateRequestDto {
+
+    @NotNull
+    private Long fileId;
+
+    //it should start with "/"
+    @Pattern(regexp = "^/.*", message = "Path는 /로 시작해야 합니다.")
+    @NotNull(message = "Path에 null이 들어오면 안됩니다.")
+    private String path;
+
+    @NotNull(message = "content에 null이 들어오면 안됩니다.")
+    private String content;
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/PathGenerator.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/model/PathGenerator.java
@@ -1,0 +1,20 @@
+package goorm.dbjj.ide.domain.fileDirectory.id.model;
+
+import goorm.dbjj.ide.domain.fileDirectory.id.FileMetadata;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PathGenerator {
+
+    @Value("${app.efs-root-directory}")
+    private String ROOT_DIRECTORY;
+
+    public String getPath(FileMetadata metadata) {
+        return ROOT_DIRECTORY + "/" + metadata.getProject().getId() + metadata.getPath();
+    }
+
+    public String getPath(String projectId, String path) {
+        return ROOT_DIRECTORY + "/" + projectId + path;
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/initiator/ProjectDirectoryInitiator.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/initiator/ProjectDirectoryInitiator.java
@@ -1,9 +1,12 @@
 package goorm.dbjj.ide.domain.fileDirectory.initiator;
 
 import goorm.dbjj.ide.container.ProgrammingLanguage;
+import goorm.dbjj.ide.domain.fileDirectory.id.FileMetadata;
+import goorm.dbjj.ide.domain.fileDirectory.id.FileMetadataRepository;
 import goorm.dbjj.ide.domain.project.model.Project;
 import goorm.dbjj.ide.storageManager.StorageManager;
 import goorm.dbjj.ide.storageManager.exception.CustomIOException;
+import goorm.dbjj.ide.storageManager.model.ResourceType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,6 +24,7 @@ public class ProjectDirectoryInitiator {
     private String baseDir;
 
     private final StorageManager storageManager;
+    private final FileMetadataRepository fileMetadataRepository;
 
     /**
      * 프로젝트 디렉터리를 생성합니다.
@@ -34,7 +38,7 @@ public class ProjectDirectoryInitiator {
         storageManager.createDirectory(path);
 
         //기본 파일 생성
-        createDefaultFile(path, project.getProgrammingLanguage());
+        createDefaultFile(project, path, project.getProgrammingLanguage());
     }
 
     /**
@@ -43,12 +47,16 @@ public class ProjectDirectoryInitiator {
      * @param path
      * @param programmingLanguage
      */
-    private void createDefaultFile(String path, ProgrammingLanguage programmingLanguage) throws CustomIOException {
+    private void createDefaultFile(Project project, String path, ProgrammingLanguage programmingLanguage) throws CustomIOException {
 
         String fileName = getFileName(programmingLanguage);
         String content = getFileContent(programmingLanguage);
 
+
+        fileMetadataRepository.save(new FileMetadata(project, "/" + fileName, ResourceType.FILE));
         storageManager.saveFile(path + "/" + fileName, content);
+
+        fileMetadataRepository.save(new FileMetadata(project, "/readme.md", ResourceType.FILE));
         storageManager.saveFile(path + "/readme.md", "대박징조 화이팅");
     }
 

--- a/src/main/java/goorm/dbjj/ide/storageManager/FileIoStorageManager.java
+++ b/src/main/java/goorm/dbjj/ide/storageManager/FileIoStorageManager.java
@@ -87,6 +87,12 @@ public class FileIoStorageManager implements StorageManager {
     }
 
     @Override
+    public boolean exists(String path) throws CustomIOException {
+        File file = new File(path);
+        return file.exists();
+    }
+
+    @Override
     public Resource loadDirectory(String path) throws CustomIOException { // 경로, resourceType + fileName,
         File file = new File(path);
 

--- a/src/main/java/goorm/dbjj/ide/storageManager/StorageManager.java
+++ b/src/main/java/goorm/dbjj/ide/storageManager/StorageManager.java
@@ -15,4 +15,6 @@ public interface StorageManager {
     Resource loadDirectory(String path) throws CustomIOException;
 
     void createDirectory(String path) throws CustomIOException;
+
+    boolean exists(String path) throws CustomIOException;
 }

--- a/src/main/java/goorm/dbjj/ide/storageManager/model/ResourceDto.java
+++ b/src/main/java/goorm/dbjj/ide/storageManager/model/ResourceDto.java
@@ -1,6 +1,7 @@
 package goorm.dbjj.ide.storageManager.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.*;
 
 import java.util.List;
@@ -10,7 +11,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonInclude(JsonInclude.Include.ALWAYS) // null값 무시
+@JsonInclude(JsonInclude.Include.NON_NULL) // null값 무시
+@JsonPropertyOrder({"id", "name", "type", "path", "children"})
 public class ResourceDto {
     private long id;
     private String name;

--- a/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatchEvent.java
+++ b/src/main/java/goorm/dbjj/ide/util/filewatcher/FileWatchEvent.java
@@ -12,6 +12,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class FileWatchEvent {
 
+    private Long fileId;
     private FileWatchEventType event;
     private ResourceType type;
     private String path;


### PR DESCRIPTION
기능 추가
* /api/v2/files 로 수행되는 API를 호출하면 파일에 ID를 부여하여 관리할 수 있습니다.

추후 해야할 일
* 최초 생성되는 파일들에도 ID 부여하기
* 파일 변경 감지를 통한 전송 DTO에 ID 담기