### PR TITLE
feat: IDE-139-DeleteFile이 먼저 수행되는 이슈 해결

### DIFF
--- a/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/IdManagedProjectFileService.java
+++ b/src/main/java/goorm/dbjj/ide/domain/fileDirectory/id/IdManagedProjectFileService.java
@@ -173,7 +173,6 @@ public class IdManagedProjectFileService {
         }
 
         storageManager.deleteFile(pathGenerator.getPath(fileMetadata));
-        fileMetadataRepository.delete(fileMetadata);
     }
 
     /**


### PR DESCRIPTION
기능 변경
* 파일이 먼저 삭제되어서 FileWatcher에서 id를 못찾는 경우에 대해 해결합니다.