### PR TITLE
IDE-79 JWT 토큰 재발급 -  PostMapping으로 수정

### DIFF
--- a/src/main/java/goorm/dbjj/ide/auth/AuthController.java
+++ b/src/main/java/goorm/dbjj/ide/auth/AuthController.java
@@ -1,0 +1,32 @@
+package goorm.dbjj.ide.auth;
+
+import goorm.dbjj.ide.api.ApiResponse;
+import goorm.dbjj.ide.auth.jwt.TokenInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    // Refresh Token 받아오면 새로운 jwt 토큰 발급
+    @PostMapping("/refresh-token")
+    public ApiResponse<TokenInfo> getTokens(
+            @RequestHeader("Authorization-refresh") String refreshToken
+    ){
+        log.trace("AuthController.getTokens() 실행 : refresh-token: {}", refreshToken);
+
+        // 'Bearer ' 접두사 제거
+        String cleanToken = refreshToken.startsWith("Bearer ") ? refreshToken.substring(7) : refreshToken;
+
+        // 새로운 토큰 발급
+        TokenInfo newTokens = authService.issuingToken(cleanToken);
+
+        // ApiResponse 객체를 통해 응답 반환
+        return ApiResponse.ok(newTokens);
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/auth/AuthService.java
+++ b/src/main/java/goorm/dbjj/ide/auth/AuthService.java
@@ -1,0 +1,36 @@
+package goorm.dbjj.ide.auth;
+
+import goorm.dbjj.ide.auth.jwt.JwtAuthProvider;
+import goorm.dbjj.ide.auth.jwt.TokenInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtAuthProvider jwtAuthProvider;
+
+    public TokenInfo issuingToken(String refreshToken){
+
+        // 1. 새로운 토큰 발급
+        TokenInfo newTokens = jwtAuthProvider.renewTokens(refreshToken);
+
+        // 2. 발급된 새 리프레시 토큰을 DB에 저장
+        // @Transactional 어노테이션이 있으므로 DB에 반영됩니다.
+
+        // 3. Authentication 업데이트
+        Authentication authentication = jwtAuthProvider.getAuthentication(newTokens.getAccessToken());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // 4. 클라이언트에게 던지기 위해 발급된 토큰에 Bearer 붙이기.
+        newTokens.setAccessToken("Bearer "+newTokens.getAccessToken());
+        newTokens.setRefreshToken("Bearer "+newTokens.getRefreshToken());
+
+        return newTokens;
+    }
+}

--- a/src/main/java/goorm/dbjj/ide/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/goorm/dbjj/ide/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -49,14 +49,14 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             loginSuccess(response, oAuth2User);
 
         } catch (Exception e){ // OAuth2 인증 후 처리에서 문제 발생.
-            log.debug("로그인 실패", e);
+            log.debug("소셜 로그인 실패 : ", e);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "로그인 처리 중 오류가 발생했습니다.");
         }
     }
 
     /**
      *  로그인 성공 시 access, refresh 토큰 생성
-      */
+     */
     private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
 
         TokenInfo tokenInfo = jwtIssuer.createToken(oAuth2User.getEmail(),"ROLE_USER");
@@ -75,8 +75,9 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 .orElseThrow(() -> new EntityNotFoundException("유저 정보가 없습니다."));
 
         //토큰과 함께 프론트엔드로 전달
-        String token = "Bearer "+tokenInfo.getAccessToken();
-        response.sendRedirect("http://localhost:3000?token="+token+"&refresh_token="+tokenInfo.getRefreshToken());
+        String accessToken = "Bearer "+tokenInfo.getAccessToken();
+        String refreshToken = "Bearer "+tokenInfo.getRefreshToken();
+        response.sendRedirect("http://localhost:3000?token="+accessToken+"&refresh_token="+refreshToken);
     }
 
     private void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken){


### PR DESCRIPTION
**[ 변경사항 ]**
- 재발급된 jwt 토큰을 response body로 전달
- 프론트에 jwt 토큰 전달할 때 refresh token도 "Bearer " 붙여서 전달
<br>

**[ jwt 토큰 재발급 로직 변경 이유 ]**
- jwt 토큰을 쿼리 파라미터로 넘기면서, jwt 토큰 넘기는 방식 변경됨.
- jwt 토큰을 넘기는 로직이 쿼리 파라미터로 바뀐 뒤, refresh 토큰을 가지고 재발급 받는 로직은 수정 안됨.
- 기존 access token이 만료 될 예정이거나 만료 되었을 때, PostMapping "/refresh-token" 으로 refresh token을 넣어서 보내주면 재발급 후 response body에 jwt 토큰 담아서 전달