### PR TITLE
hotfix: Project 조회 쿼리 메서드 수정 - 참여 - 생성 구분

### DIFF
--- a/src/main/java/goorm/dbjj/ide/domain/project/ProjectRepository.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/ProjectRepository.java
@@ -5,6 +5,8 @@ import goorm.dbjj.ide.domain.user.dto.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProjectRepository extends JpaRepository<Project, String> {
 
@@ -15,4 +17,7 @@ public interface ProjectRepository extends JpaRepository<Project, String> {
      * @return
      */
     Page<Project> findByCreator(User creator, Pageable pageable);
+
+    @Query("SELECT p FROM Project p JOIN p.projectUsers pu WHERE pu.user = :user AND p.creator != :user")
+    Page<Project> findByParticipatingUserAndNotCreator(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/goorm/dbjj/ide/domain/project/ProjectService.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/ProjectService.java
@@ -18,7 +18,9 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -198,16 +200,19 @@ public class ProjectService {
     public Page<ProjectDto> findMyCreatedProject(User user, Pageable pageable) {
         User mergedUser = em.merge(user);
 
-        return projectRepository.findByCreator(mergedUser, pageable)
-                .map(ProjectDto::of);
+        Sort.Order order = new Sort.Order(Sort.Direction.DESC, "createdAt");
+        PageRequest req = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(order));
+
+        return projectRepository.findByCreator(mergedUser, req).map(ProjectDto::of);
     }
 
     public Page<ProjectDto> findMyJoinedProject(User user, Pageable pageable) {
         User mergedUser = em.merge(user);
 
-        return projectUserRepository.findByUser(mergedUser, pageable)
-                .map(ProjectUser::getProject)
-                .map(ProjectDto::of);
+        Sort.Order order = new Sort.Order(Sort.Direction.DESC, "createdAt");
+        PageRequest req = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(order));
+
+        return projectRepository.findByParticipatingUserAndNotCreator(mergedUser, req).map(ProjectDto::of);
     }
 
     public ProjectDto findProjectById(String projectId) {

--- a/src/main/java/goorm/dbjj/ide/domain/project/ProjectUserRepository.java
+++ b/src/main/java/goorm/dbjj/ide/domain/project/ProjectUserRepository.java
@@ -9,12 +9,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectUserRepository extends JpaRepository<ProjectUser, Long> {
     boolean existsByProjectAndUser(Project project, User user);
-
-    /**
-     * 유저가 참여한 프로젝트 목록 조회
-     * @param user
-     * @param pageable
-     * @return
-     */
-    Page<ProjectUser> findByUser(User user, Pageable pageable);
 }


### PR DESCRIPTION
이제 참여한 프로젝트에 생성한 프로젝트가 등장하지 않습니다.